### PR TITLE
Fix gnext release promotion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,3 +8,4 @@
 - gnext and gnextall now explicitly set the `testing` tag.
 - Simplified `set-next` and `set-next-all` to only accept `-r`; prerelease uses
   the `testing` tag by default.
+- gnext -r now removes the `testing` tag and creates a release tag.

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -290,6 +290,13 @@ set_next_release() {
   done
   shift $((OPTIND - 1))
   if [ "$release" -eq 1 ]; then
+    if git rev-parse testing >/dev/null 2>&1; then
+      git tag -d testing
+      git push -d origin testing || true
+      if command -v gh >/dev/null 2>&1; then
+        gh release delete -y testing >/dev/null 2>&1 || true
+      fi
+    fi
     last=$(git tag -l 'v*' | sort -V | tail -n 1)
     if [ -n "$last" ]; then
       next=$(echo "${last#v}" | awk -F. '{if(NF==1){printf "%d",$1+1}else if(NF==2){printf "%d.%d",$1,$2+1}else{printf "%d.%d.%d",$1,$2,$3+1}}')


### PR DESCRIPTION
## Summary
- ensure `gnext -r` cleans up the `testing` tag
- document the new behaviour in the changelog

## Testing
- `shellcheck scripts/githelper.sh`
- `shellcheck scripts/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b11e0196c8327bcb7f687bc5b841d