### PR TITLE
Fix clone install and shortcut

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,3 +10,5 @@
   the `testing` tag by default.
 - gnext -r now removes the `testing` tag and creates a release tag.
 - Pre-releases now list commits since the previous tag when creating GitHub releases.
+- githelper-setnextall shortcut no longer forces the `testing` tag.
+- Installer with `-g` clones first and installs from the clone to avoid duplicate downloads.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install the testing version run:
 curl -L https://github.com/alexknuckles/termux-scripts/releases/download/testing/installer.sh | bash -s -- -r
 ```
 
-Use `-g` along with `-r` to also clone the repository to `~/git/termux-scripts` after installing.
+Use `-g` to clone the repository to `~/git/termux-scripts` first and install from that local copy, avoiding an additional download.
 The installer updates your shell configuration to source every `*.aliases` file in `~/.aliases.d/` on startup.
 Shortcut scripts are located in the `termux-scripts-shortcuts` directory.
 Run the installer with `-u` to remove the symlinks, shortcuts and alias file and clean up the shell configuration.

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -50,7 +50,6 @@ while getopts ":rgu" opt; do
       remote=1
       ;;
     g)
-      remote=1
       clone_repo=1
       ;;
     u)
@@ -82,7 +81,18 @@ if [ "$uninstall" -eq 1 ]; then
   exit 0
 fi
 
-if [ "$remote" -eq 1 ]; then
+if [ "$clone_repo" -eq 1 ]; then
+  mkdir -p "$HOME/git"
+  if [ -d "$HOME/git/termux-scripts/.git" ]; then
+    git -C "$HOME/git/termux-scripts" pull --ff-only || true
+  else
+    git clone "$REPO_URL" "$HOME/git/termux-scripts"
+  fi
+  ROOT_DIR="$HOME/git/termux-scripts"
+  SCRIPTS_DIR="$ROOT_DIR/scripts"
+  ALIASES_FILE="$ROOT_DIR/aliases/termux-scripts.aliases"
+  SHORTCUTS_DIR="$ROOT_DIR/termux-scripts-shortcuts"
+elif [ "$remote" -eq 1 ]; then
   tag=$(curl -sL "https://api.github.com/repos/alexknuckles/termux-scripts/releases/latest" | jq -r .tag_name)
   [ -n "$tag" ] || tag=main
   tmpdir=$(mktemp -d)
@@ -93,8 +103,8 @@ if [ "$remote" -eq 1 ]; then
   SHORTCUTS_DIR="$ROOT_DIR/termux-scripts-shortcuts"
 fi
 
-if [ "$remote" -eq 0 ] && [ -f "$VERSION_FILE" ] && \
-   [ "$(cat "$VERSION_FILE")" = "$VERSION" ]; then
+if [ "$remote" -eq 0 ] && [ "$clone_repo" -eq 0 ] && \
+   [ -f "$VERSION_FILE" ] && [ "$(cat "$VERSION_FILE")" = "$VERSION" ]; then
   echo "Termux scripts version $VERSION already installed"
   exit 0
 fi
@@ -162,10 +172,5 @@ echo "Installed githelper to $TARGET_BIN/githelper"
 echo "$VERSION" > "$VERSION_FILE"
 
 if [ "$clone_repo" -eq 1 ]; then
-  mkdir -p "$HOME/git"
-  if [ -d "$HOME/git/termux-scripts/.git" ]; then
-    git -C "$HOME/git/termux-scripts" pull --ff-only || true
-  else
-    git clone "$REPO_URL" "$HOME/git/termux-scripts"
-  fi
+  echo "Repository cloned to $HOME/git/termux-scripts"
 fi

--- a/termux-scripts-shortcuts/githelper-setnextall.sh
+++ b/termux-scripts-shortcuts/githelper-setnextall.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # githelper-setnextall.sh - run githelper set-next-all
 # TAG: shortcut
 
-exec githelper set-next-all -t testing "$@"
+exec githelper set-next-all "$@"


### PR DESCRIPTION
## Summary
- remove `-t testing` from githelper-setnextall shortcut
- clone before installing when using `-g`
- update README and changelog

## Testing
- `bash -n scripts/installer.sh`
- `bash -n termux-scripts-shortcuts/githelper-setnextall.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b18da63d88327bb2b8588904c978a