### PR TITLE
Add PATH export during install

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,3 +13,4 @@
 - githelper-setnextall shortcut no longer forces the `testing` tag.
 - Installer with `-g` clones first and installs from the clone to avoid duplicate downloads.
 - Documented Termux, Termux Widget and Termux API requirements with F-Droid links.
+- Installer now ensures `~/bin/termux-scripts` is on the PATH and exports it for immediate use.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of small utilities for the Termux environment.
 - [Termux:API](https://f-droid.org/packages/com.termux.api/) for wallpaper and other integrations
 
 ## Installation
-Run `./scripts/installer.sh` to install the scripts. They are copied to `~/bin/termux-scripts`, shortcuts under `~/.shortcuts/termux-scripts`, and an alias file in `~/.aliases.d/`. Missing packages will be offered for installation automatically. The installer also sets executable permissions so commands like `gpullall` and `gpull` work immediately. Pass `-u` to remove everything created by a previous run.
+Run `./scripts/installer.sh` to install the scripts. They are copied to `~/bin/termux-scripts`, shortcuts under `~/.shortcuts/termux-scripts`, and an alias file in `~/.aliases.d/`. Missing packages will be offered for installation automatically. The installer also sets executable permissions so commands like `gpullall` and `gpull` work immediately. It adds `~/bin/termux-scripts` to your `PATH` and exports it so the utilities are available right away. Pass `-u` to remove everything created by a previous run.
 
 To install the stable release without cloning the repository run:
 

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -156,6 +156,20 @@ EOF
   fi
 fi
 
+shell_rc=""
+for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
+  if [ -f "$rc" ]; then
+    shell_rc="$rc"
+    break
+  fi
+done
+if [ -n "$shell_rc" ] && ! grep -Fq "$HOME/bin/termux-scripts" "$shell_rc"; then
+  echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$shell_rc"
+fi
+
+# Make new commands available immediately
+export PATH="$INSTALL_DIR:$PATH"
+
 if [ -d "$SHORTCUTS_DIR" ]; then
   dest="$HOME/.shortcuts/termux-scripts"
   mkdir -p "$dest"


### PR DESCRIPTION
## Summary
- ensure installer exports `~/bin/termux-scripts` immediately after install
- mention PATH export in README and CHANGES

## Testing
- `bash -n scripts/installer.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b1cb6264c8327a21fdb60e0b88e62