### PR TITLE
Fix installer path setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,3 +14,4 @@
 - Installer with `-g` clones first and installs from the clone to avoid duplicate downloads.
 - Documented Termux, Termux Widget and Termux API requirements with F-Droid links.
 - Installer now ensures `~/bin/termux-scripts` is on the PATH and exports it for immediate use.
+- Installer now appends the path to `~/.bashrc`, sources it and loads the alias file immediately.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of small utilities for the Termux environment.
 - [Termux:API](https://f-droid.org/packages/com.termux.api/) for wallpaper and other integrations
 
 ## Installation
-Run `./scripts/installer.sh` to install the scripts. They are copied to `~/bin/termux-scripts`, shortcuts under `~/.shortcuts/termux-scripts`, and an alias file in `~/.aliases.d/`. Missing packages will be offered for installation automatically. The installer also sets executable permissions so commands like `gpullall` and `gpull` work immediately. It adds `~/bin/termux-scripts` to your `PATH` and exports it so the utilities are available right away. Pass `-u` to remove everything created by a previous run.
+Run `./scripts/installer.sh` to install the scripts. They are copied to `~/bin/termux-scripts`, shortcuts under `~/.shortcuts/termux-scripts`, and an alias file in `~/.aliases.d/`. Missing packages will be offered for installation automatically. The installer also sets executable permissions so commands like `gpullall` and `gpull` work immediately. It appends `~/bin/termux-scripts` to your `~/.bashrc` and exports it so the utilities are available right away. The alias file is sourced as soon as it's installed. Pass `-u` to remove everything created by a previous run.
 
 To install the stable release without cloning the repository run:
 

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -154,17 +154,18 @@ if [ -d "$HOME/.aliases.d" ]; then
 fi
 EOF
   fi
+  # Load aliases for this session
+  . "$alias_target"
 fi
 
-shell_rc=""
-for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
-  if [ -f "$rc" ]; then
-    shell_rc="$rc"
-    break
-  fi
-done
-if [ -n "$shell_rc" ] && ! grep -Fq "$HOME/bin/termux-scripts" "$shell_rc"; then
-  echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$shell_rc"
+bash_rc="$HOME/.bashrc"
+if [ ! -f "$bash_rc" ]; then
+  touch "$bash_rc"
+fi
+if ! grep -Fq "$HOME/bin/termux-scripts" "$bash_rc"; then
+  echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$bash_rc"
+  # Apply changes to current session
+  . "$bash_rc"
 fi
 
 # Make new commands available immediately


### PR DESCRIPTION
## Summary
- source alias file after installation
- put PATH export in ~/.bashrc and source it immediately
- document automatic sourcing in README
- note installer change in CHANGES.md

## Testing
- `shellcheck scripts/installer.sh`
- `shellcheck scripts/githelper.sh`
- `shellcheck scripts/wallai.sh`
- `bash -n scripts/installer.sh`
- `sudo apt-get update`
- `sudo apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_685b252599248327b07d72163604d960