### PR TITLE
Fix gnext auth prompt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,3 +15,5 @@
 - Documented Termux, Termux Widget and Termux API requirements with F-Droid links.
 - Installer now ensures `~/bin/termux-scripts` is on the PATH and exports it for immediate use.
 - Installer now appends the path to `~/.bashrc`, sources it and loads the alias file immediately.
+
+- gnext and gnextall now configure gh git credentials automatically when needed.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Examples:
 - `githelper revert-last` reverts the most recent commit.
 - `githelper clone-mine` clones all your GitHub repositories to `~/git`. Specify a different user with `-u`.
 - `githelper newrepo [-d dir] [-ns] [description]` creates a new repo with an AI-generated README and agents file. Scanning files is enabled by default; use `-ns` to disable scanning and `-d` to specify a different directory.
- - `githelper set-next` creates a prerelease with the `testing` tag by default. Use `-r` for a full release which automatically increments from the latest `v*` tag.
- - `githelper set-next-all` runs the same command across every repository in `~/git`.
+- `githelper set-next` creates a prerelease with the `testing` tag by default. Use `-r` for a full release which automatically increments from the latest `v*` tag.
+- `githelper set-next-all` runs the same command across every repository in `~/git`.
+- Both commands ensure `gh auth setup-git` has configured credentials so pushes won't prompt for a password.
 
 Dependencies: `git`, `jq`, optional `gh` for GitHub integration.

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -289,6 +289,13 @@ set_next_release() {
     esac
   done
   shift $((OPTIND - 1))
+  if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+      echo "No GitHub authentication found. Launching gh auth login..." >&2
+      gh auth login
+    fi
+    gh auth setup-git >/dev/null 2>&1 || true
+  fi
   if [ "$release" -eq 1 ]; then
     if git rev-parse testing >/dev/null 2>&1; then
       git tag -d testing


### PR DESCRIPTION
## Summary
- configure gh git credentials in `githelper set-next` so releasing tags doesn't prompt for a password
- document new behavior in README
- note change in CHANGES

## Testing
- `shellcheck scripts/*.sh`
- `bash -n scripts/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b279bc3ec832789b5e827cfe8c932