### PR TITLE
Fix PATH for widget shortcuts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,3 +17,5 @@
 - Installer now appends the path to `~/.bashrc`, sources it and loads the alias file immediately.
 
 - gnext and gnextall now configure gh git credentials automatically when needed.
+
+- Shortcut scripts now use absolute paths to installed commands for reliability with Termux Widget.

--- a/termux-scripts-shortcuts/githelper-clonemine.sh
+++ b/termux-scripts-shortcuts/githelper-clonemine.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # githelper-clonemine.sh - run githelper clone-mine
 # TAG: shortcut
 
-exec githelper clone-mine "$@"
+exec "$HOME/bin/termux-scripts/githelper" clone-mine "$@"

--- a/termux-scripts-shortcuts/githelper-pullall.sh
+++ b/termux-scripts-shortcuts/githelper-pullall.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # githelper-pullall.sh - run githelper pull-all
 # TAG: shortcut
 
-exec githelper pull-all "$@"
+exec "$HOME/bin/termux-scripts/githelper" pull-all "$@"

--- a/termux-scripts-shortcuts/githelper-pushall.sh
+++ b/termux-scripts-shortcuts/githelper-pushall.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # githelper-pushall.sh - run githelper push-all
 # TAG: shortcut
 
-exec githelper push-all "$@"
+exec "$HOME/bin/termux-scripts/githelper" push-all "$@"

--- a/termux-scripts-shortcuts/githelper-setnextall.sh
+++ b/termux-scripts-shortcuts/githelper-setnextall.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # githelper-setnextall.sh - run githelper set-next-all
 # TAG: shortcut
 
-exec githelper set-next-all "$@"
+exec "$HOME/bin/termux-scripts/githelper" set-next-all "$@"

--- a/termux-scripts-shortcuts/githelper-shortcut.sh
+++ b/termux-scripts-shortcuts/githelper-shortcut.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 # githelper shortcut
-exec githelper "$@"
+exec "$HOME/bin/termux-scripts/githelper" "$@"

--- a/termux-scripts-shortcuts/wallai-shortcut.sh
+++ b/termux-scripts-shortcuts/wallai-shortcut.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # wallai-shortcut.sh - simple wrapper to launch wallai
 # TAG: shortcut
 
-exec wallai "$@"
+exec "$HOME/bin/termux-scripts/wallai" "$@"


### PR DESCRIPTION
## Summary
- call installed scripts via full path in Termux widget shortcuts
- document change

## Testing
- `shellcheck termux-scripts-shortcuts/*.sh`
- `bash -n termux-scripts-shortcuts/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b299941908327aec95b71e71016b5