### PR TITLE
Add wallpaper save feature with metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,3 +19,4 @@
 - gnext and gnextall now configure gh git credentials automatically when needed.
 
 - Shortcut scripts now use absolute paths to installed commands for reliability with Termux Widget.
+- wallai now logs prompts with filenames and can archive the last wallpaper with exif metadata using `-s`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ due to low quality. The default model is `flux`.
 
 ### Usage
 ```bash
-wallai [-p "prompt text"] [-t theme] [-m model] [-r]
+wallai [-p "prompt text"] [-t theme] [-m model] [-r] [-s]
 ```
 
 Environment variables:
@@ -53,6 +53,7 @@ Flags:
   The `gptimage` model requires a flower-tier Pollinations account; without
   access the API returns an error. The `turbo` model tends to produce lower quality images.
 - `-r` Pick a random model from the available list, excluding `gptimage` and `turbo`.
+- `-s` Save the latest generated wallpaper to `~/pictures/saved-generated-wallpapers/` with the prompt embedded using `exiftool`.
 
 After showing the chosen prompt, the script also prints which Pollinations model will
 be used for image generation.
@@ -62,10 +63,13 @@ API using a random genre such as fantasy or cyberpunk. You can override the rand
 `-t theme`. The API is asked to respond in exactly 15 words. A random seed parameter ensures that
 repeated calls yield different descriptions even when the theme is the same.
 
-Dependencies: `curl`, `jq`, `termux-wallpaper`.
+Dependencies: `curl`, `jq`, `termux-wallpaper`, optional `exiftool` for `-s`.
 If any of these tools are missing the script exits with a clear error
 message. Internet access is required for fetching prompts and generating
 the image.
+
+The installer creates a `walsave` alias and `wallai-save-shortcut.sh` so you
+can quickly archive the most recent wallpaper with metadata.
 
 ## githelper.sh
 

--- a/aliases/termux-scripts.aliases
+++ b/aliases/termux-scripts.aliases
@@ -1,5 +1,6 @@
 # Short aliases for Termux scripts
 alias wal='wallai'
+alias walsave='wallai -s'
 alias gpullall='githelper pull-all'
 alias gpull='githelper pull'
 alias gpushall='githelper push-all'

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -14,22 +14,31 @@ prompt=""
 theme=""
 model="flux"
 random_model=false
-while getopts ":p:t:m:r" opt; do
+save_wall=false
+generation_opts=false
+while getopts ":p:t:m:rs" opt; do
   case "$opt" in
     p)
       prompt="$OPTARG"
+      generation_opts=true
       ;;
     t)
       theme="$OPTARG"
+      generation_opts=true
       ;;
     m)
       model="$OPTARG"
+      generation_opts=true
       ;;
     r)
       random_model=true
+      generation_opts=true
+      ;;
+    s)
+      save_wall=true
       ;;
     *)
-      echo "Usage: wallai.sh [-p \"prompt text\"] [-t theme] [-m model] [-r]" >&2
+      echo "Usage: wallai.sh [-p \"prompt text\"] [-t theme] [-m model] [-r] [-s]" >&2
       exit 1
       ;;
   esac
@@ -57,7 +66,7 @@ fi
 
 # wallai.sh - generate a wallpaper using Pollinations
 #
-# Usage: wallai.sh [-p "prompt text"] [-t theme] [-m model] [-r]
+# Usage: wallai.sh [-p "prompt text"] [-t theme] [-m model] [-r] [-s]
 # Environment variables:
 #   ALLOW_NSFW         Set to 'false' to disallow NSFW prompts (default 'true')
 # Flags:
@@ -66,8 +75,9 @@ fi
 #   -m model        Pollinations model (defaults to 'flux'). Supported models
 #                   are fetched from the API (fallback: flux turbo gptimage)
 #   -r              Pick a random model from the available list
+#   -s              Save the latest generated wallpaper with prompt metadata
 #
-# Dependencies: curl, jq, termux-wallpaper
+# Dependencies: curl, jq, termux-wallpaper, optional exiftool for -s
 # Output: saves the generated image under ~/pictures/generated-wallpapers
 # TAG: wallpaper
 # TAG: ai
@@ -153,3 +163,40 @@ img_source="Pollinations"
 termux-wallpaper -f "$output"
 echo "🎉 Wallpaper set from prompt: $prompt" "(source: $img_source)"
 echo "💾 Saved to: $output"
+
+# Log filename and prompt for later reference
+log_file="$save_dir/wallai.log"
+echo "$filename|$prompt" >> "$log_file"
+
+# Function to archive the most recent wallpaper with metadata using exiftool
+archive_wall() {
+  command -v exiftool >/dev/null 2>&1 || {
+    echo "❌ exiftool is required for -s" >&2
+    return 1
+  }
+  local file="$1" meta="$2"
+  local dest_dir="$HOME/pictures/saved-generated-wallpapers"
+  mkdir -p "$dest_dir"
+  local dest
+  dest="$dest_dir/$(basename "$file")"
+  cp "$file" "$dest"
+  exiftool -overwrite_original -Comment="$meta" "$dest" >/dev/null
+  echo "📂 Archived wallpaper to: $dest"
+}
+
+# If called only with -s, archive the last generated wallpaper and exit
+if [ "$save_wall" = true ] && [ "$generation_opts" = false ]; then
+  last_entry=$(tail -n1 "$log_file" 2>/dev/null || true)
+  if [ -z "$last_entry" ]; then
+    echo "❌ No wallpaper has been generated yet" >&2
+    exit 1
+  fi
+  last_file=$(printf '%s' "$last_entry" | cut -d'|' -f1)
+  last_prompt=$(printf '%s' "$last_entry" | cut -d'|' -f2-)
+  archive_wall "$save_dir/$last_file" "$last_prompt"
+  exit 0
+fi
+
+# Archive the wallpaper immediately if -s was passed alongside generation options
+[ "$save_wall" = true ] && archive_wall "$output" "$prompt"
+

--- a/termux-scripts-shortcuts/wallai-save-shortcut.sh
+++ b/termux-scripts-shortcuts/wallai-save-shortcut.sh
@@ -1,0 +1,7 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# wallai-save-shortcut.sh - archive the latest generated wallpaper
+# TAG: shortcut
+
+exec "$HOME/bin/termux-scripts/wallai" -s "$@"


### PR DESCRIPTION
## Summary
- log prompts with generated image filenames
- add `-s` flag in `wallai` to archive generated wallpaper with `exiftool`
- create `walsave` alias and shortcut
- document new option in README
- record change in CHANGES

## Testing
- `shellcheck scripts/wallai.sh termux-scripts-shortcuts/wallai-save-shortcut.sh`
- `bash -n scripts/wallai.sh`
- `bash -n termux-scripts-shortcuts/wallai-save-shortcut.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b2e3312e08327914b1f2a4524936d