### PR TITLE
Fix Pollinations image format detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,3 +21,4 @@
 - Shortcut scripts now use absolute paths to installed commands for reliability with Termux Widget.
 - wallai now logs prompts with filenames and can archive the last wallpaper with exif metadata using `-s`.
 - New `walsave` alias archives the current wallpaper without generating a new image.
+- wallai now names wallpapers with the correct extension based on the API response.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ API using a random genre such as fantasy or cyberpunk. You can override the rand
 repeated calls yield different descriptions even when the theme is the same.
 
 Dependencies: `curl`, `jq`, `termux-wallpaper`, optional `exiftool` for `-s` or `walsave`.
+Images are saved as PNG or JPEG depending on what the API returns.
 If any of these tools are missing the script exits with a clear error
 message. Internet access is required for fetching prompts and generating
 the image.


### PR DESCRIPTION
## Summary
- detect Pollinations API content type in wallai
- rename saved wallpaper with correct extension
- document that images may be PNG or JPG
- note extension fix in `CHANGES.md`

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck scripts/wallai.sh scripts/walsave.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b35c81e6083279dc06da5efb275a1