### PR TITLE
Improve githelper newrepo reliability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,3 +27,4 @@
 - Renamed wallai-save shortcut to walsave-shortcut for clarity.
 - Uninstaller now spawns a fresh shell to remove loaded aliases.
 - githelper newrepo now requires `-m` for the description and uses `-n` to disable scanning.
+- githelper newrepo gracefully handles invalid Pollinations responses.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Examples:
 - `githelper init` initializes a new repo in the current directory.
 - `githelper revert-last` reverts the most recent commit.
 - `githelper clone-mine` clones all your GitHub repositories to `~/git`. Specify a different user with `-u`.
-- `githelper newrepo [-d dir] [-n] [-m description]` creates a new repo with an AI-generated README and agents file. Scanning files is enabled by default; use `-n` to disable scanning, `-d` to choose a directory and `-m` to provide a description.
+- `githelper newrepo [-d dir] [-n] [-m description]` creates a new repo with an AI-generated README and agents file. Scanning files is enabled by default; use `-n` to disable scanning, `-d` to choose a directory and `-m` to provide a description. The script uses the Pollinations API but falls back to plain text if the response isn't valid JSON.
 - `githelper set-next` creates a prerelease with the `testing` tag by default. Use `-r` for a full release which automatically increments from the latest `v*` tag.
 - `githelper set-next-all` runs the same command across every repository in `~/git`.
 - Both commands ensure `gh auth setup-git` has configured credentials so pushes won't prompt for a password.

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -235,7 +235,13 @@ new_repo() {
     prompt="Create a professional README.md for a software project that includes: $file_list. Include a project description, features, and usage."
   fi
   encoded=$(printf '%s' "$prompt" | jq -sRr @uri)
-  readme=$(curl -sL "https://text.pollinations.ai/prompt/${encoded}" | jq -r '.completion' || true)
+  local response
+  response=$(curl -sL "https://text.pollinations.ai/prompt/${encoded}" || true)
+  if printf '%s' "$response" | jq -e . >/dev/null 2>&1; then
+    readme=$(printf '%s' "$response" | jq -r '.completion')
+  else
+    readme="$response"
+  fi
   [ -n "$readme" ] || readme="# $project_name"
   printf '%s\n' "$readme" > README.md
 
@@ -247,7 +253,12 @@ new_repo() {
     prompt="Create an agents.md file for a project with these files: $file_list. Define Docs agent, Code agent, Build agent, and Test agent. List their roles and goals."
   fi
   encoded=$(printf '%s' "$prompt" | jq -sRr @uri)
-  agents=$(curl -sL "https://text.pollinations.ai/prompt/${encoded}" | jq -r '.completion' || true)
+  response=$(curl -sL "https://text.pollinations.ai/prompt/${encoded}" || true)
+  if printf '%s' "$response" | jq -e . >/dev/null 2>&1; then
+    agents=$(printf '%s' "$response" | jq -r '.completion')
+  else
+    agents="$response"
+  fi
   [ -n "$agents" ] && printf '%s\n' "$agents" > agents.md
 
   local author year


### PR DESCRIPTION
## Summary
- handle non-JSON Pollinations output when generating README or agents
- document fallback in README
- note change in CHANGES

## Testing
- `bash -n scripts/githelper.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b88b6681c83279fadc91edcd3f5d1