### PR TITLE
Fix newrepo initial commit

### DIFF
--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -210,7 +210,11 @@ new_repo() {
   cd "$dir"
   git init
   git add -A
-  git commit -m "Initial commit"
+  if git diff --cached --quiet 2>/dev/null; then
+    git commit --allow-empty -m "Initial commit"
+  else
+    git commit -m "Initial commit"
+  fi
 
   local project_name
   project_name=$(basename "$dir")


### PR DESCRIPTION
## Summary
- handle empty repo initialization in `githelper newrepo`

## Testing
- `shellcheck scripts/githelper.sh`
- `bash scripts/githelper.sh newrepo -d /tmp/test_git_repo -n -m "Test repo 2"`

------
https://chatgpt.com/codex/tasks/task_e_685b97071ff8832781134ca38f26dd67