### PR TITLE
Update agents with API fallback and docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,3 +29,5 @@
 - githelper newrepo now requires `-m` for the description and uses `-n` to disable scanning.
 - githelper newrepo gracefully handles invalid Pollinations responses.
 - Fixed githelper newrepo failing when committing in an empty directory.
+- Improved wallai header comments and tags.
+- Added APIFallback agent to validate API error handling.

--- a/agents.md
+++ b/agents.md
@@ -81,6 +81,17 @@ Scan for risky patterns:
 
 ---
 
+## 🌐 APIFallback
+
+**Goal:**
+Ensure scripts gracefully handle network failures or invalid API responses:
+
+- Mock failing responses such as invalid JSON or network errors
+- Verify Pollinations integrations produce fallback output
+- Add simple tests for critical API-dependent commands
+
+---
+
 ## 🛠 Installer
 
 **Goal:**  


### PR DESCRIPTION
## Summary
- improve changelog
- define new `APIFallback` agent for validating API error handling

## Testing
- `bash -n scripts/githelper.sh scripts/installer.sh scripts/wallai.sh scripts/walsave.sh`
- `shellcheck scripts/*.sh termux-scripts-shortcuts/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ba34ee11c83279188b5a5aaa27687