### PR TITLE
Update README with remote F-Droid badge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,3 +42,5 @@
 - Removed broken listcmds script.
 - `gpush` now stages, commits with "gpush-ed", and pushes to the main branch.
 - `gpushall` now automatically stages, commits with "gpush-ed", and pushes each repo to the main branch.
+- Updated README with githelper push docs, clearer set-next notes and F-Droid badges.
+- Switched to remote F-Droid badge and removed local image.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ A collection of small utilities for the Termux environment.
 - [Termux Widget](https://f-droid.org/packages/com.termux.widget/) for shortcut support
 - [Termux:API](https://f-droid.org/packages/com.termux.api/) for wallpaper and other integrations
 
+<p align="center">
+  <a href="https://f-droid.org/packages/com.termux/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Get_it_on_F-Droid.svg/512px-Get_it_on_F-Droid.svg.png" alt="Get Termux on F-Droid" width="170" />
+  </a>
+  <a href="https://f-droid.org/packages/com.termux.widget/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Get_it_on_F-Droid.svg/512px-Get_it_on_F-Droid.svg.png" alt="Get Termux Widget on F-Droid" width="170" />
+  </a>
+  <a href="https://f-droid.org/packages/com.termux.api/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Get_it_on_F-Droid.svg/512px-Get_it_on_F-Droid.svg.png" alt="Get Termux:API on F-Droid" width="170" />
+  </a>
+</p>
+
 ## Installation
 Run `./scripts/installer.sh` to install the scripts. They are copied to `~/bin/termux-scripts`, shortcuts under `~/.shortcuts/termux-scripts`, and an alias file in `~/.aliases.d/`. Missing packages will be offered for installation automatically. The installer also sets executable permissions so commands like `gpullall` and `gpull` work immediately. It appends `~/bin/termux-scripts` to your `~/.bashrc` and exports it so the utilities are available right away. The alias file is sourced as soon as it's installed. Pass `-u` to remove everything created by a previous run.
 
@@ -28,6 +40,10 @@ Shortcut scripts are located in the `termux-scripts-shortcuts` directory.
 Run the installer with `-u` to remove the symlinks, shortcuts and alias file and clean up the shell configuration. A new shell starts afterward so any loaded aliases are cleared.
 
 ## wallai.sh
+
+<p align="center">
+  <img src="static/wallai-logo.png" alt="wallai logo" width="200" />
+</p>
 
 Generates an AI-based wallpaper using the free Pollinations API. The script requests a 15-word
 description for a random theme and includes a unique seed so prompts vary even for the same theme.
@@ -85,8 +101,10 @@ githelper <pull-all|push-all|status|pull|push|clone|init|revert-last|clone-mine|
 
 Examples:
 - `githelper pull-all` updates every repository in `~/git`.
-- `githelper push-all` pushes each repository in `~/git` to its main branch. Use `-c` to enter a commit message for all.
+- `githelper push-all` stages, commits and pushes each repository in `~/git` to its main branch. Use `-c` to enter a commit message for all.
+- `githelper status` shows a short status for the current repository.
 - `githelper pull` pulls the latest changes for the current repository.
+- `githelper push` stages any changes, commits with "gpush-ed" and pushes to `origin/main`.
 - `githelper clone -u <url>` clones a repository using `gh` if available.
 - `githelper init` initializes a new repo in the current directory.
 - `githelper revert-last` reverts the most recent commit.
@@ -94,7 +112,7 @@ Examples:
 - `githelper newrepo [-d dir] [-n] [-m description]` creates a new repo with an AI-generated README and agents file. Scanning files is enabled by default; use `-n` to disable scanning, `-d` to choose a directory and `-m` to provide a description. The script uses the Pollinations API but falls back to plain text if the response isn't valid JSON.
 - `githelper set-next` creates a prerelease with the `testing` tag by default. Use `-r` for a full release which automatically increments from the latest `v*` tag.
 - `githelper set-next-all` runs the same command across every repository in `~/git`.
-- Both commands ensure `gh auth setup-git` has configured credentials so pushes won't prompt for a password.
+- Both `set-next` and `set-next-all` ensure `gh auth setup-git` has configured credentials so pushes won't prompt for a password.
 
 Dependencies: `git`, `jq`, optional `gh` for GitHub integration.
 Use `scripts/lint.sh` to run ShellCheck and `scripts/security_check.sh` to scan for risky patterns.


### PR DESCRIPTION
## Summary
- swap local badge for remote F-Droid badge links
- document `githelper push` and status commands
- clarify which commands require GitHub auth
- add WallAI logo image in README
- note the change in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`


------
https://chatgpt.com/codex/tasks/task_e_685c1f4ae8e883279fdac021fb9bf119