### PR TITLE
Update newrepo defaults

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,3 +44,4 @@
 - `gpushall` now automatically stages, commits with "gpush-ed", and pushes each repo to the main branch.
 - Updated README with githelper push docs, clearer set-next notes and F-Droid badges.
 - Switched to remote F-Droid badge and removed local image.
+- githelper newrepo now sets the initial branch to `main` and creates a private GitHub repository named after the directory.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Examples:
 - `githelper init` initializes a new repo in the current directory.
 - `githelper revert-last` reverts the most recent commit.
 - `githelper clone-mine` clones all your GitHub repositories to `~/git`. Specify a different user with `-u`.
-- `githelper newrepo [-d dir] [-n] [-m description]` creates a new repo with an AI-generated README and agents file. Scanning files is enabled by default; use `-n` to disable scanning, `-d` to choose a directory and `-m` to provide a description. The script uses the Pollinations API but falls back to plain text if the response isn't valid JSON.
+- `githelper newrepo [-d dir] [-n] [-m description]` initializes a repository on the `main` branch and generates a README and agents file. If `gh` is installed, it creates a private GitHub repo named after the directory and pushes the initial commit. Scanning files is enabled by default; use `-n` to disable scanning, `-d` to choose a directory and `-m` to provide a description. The script uses the Pollinations API but falls back to plain text if the response isn't valid JSON.
 - `githelper set-next` creates a prerelease with the `testing` tag by default. Use `-r` for a full release which automatically increments from the latest `v*` tag.
 - `githelper set-next-all` runs the same command across every repository in `~/git`.
 - Both `set-next` and `set-next-all` ensure `gh auth setup-git` has configured credentials so pushes won't prompt for a password.

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -111,7 +111,7 @@ init_here() {
     echo "Repository already initialized" >&2
     return
   fi
-  git init
+  git init -b main
   git add -A
   git commit -m "Initial commit"
 }
@@ -190,7 +190,7 @@ new_repo() {
 
   mkdir -p "$dir"
   cd "$dir"
-  git init
+  git init -b main
   git add -A
   if git diff --cached --quiet 2>/dev/null; then
     git commit --allow-empty -m "Initial commit"
@@ -201,7 +201,7 @@ new_repo() {
   local project_name
   project_name=$(basename "$dir")
   if command -v gh >/dev/null 2>&1; then
-    gh repo create "$project_name" --source=. --public --remote=origin --push || true
+    gh repo create "$project_name" --source=. --private --remote=origin --push || true
   fi
 
   local file_list="" prompt encoded readme agents


### PR DESCRIPTION
## Summary
- githelper newrepo now initializes repos on the `main` branch
- use private visibility when creating GitHub repos
- document new defaults

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c3524757c8327a25546f8fe6ebbcc