### PR TITLE
Add bleeding-edge testing installer

### DIFF
--- a/.github/workflows/upload-installer.yml
+++ b/.github/workflows/upload-installer.yml
@@ -13,7 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Upload installer
+      - name: Upload bleeding edge installer
+        if: github.event.release.prerelease == true
+        uses: softprops/action-gh-release@v1
+        with:
+          files: scripts/testing_installer.sh#installer.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload stable installer
+        if: github.event.release.prerelease != true
         uses: softprops/action-gh-release@v1
         with:
           files: scripts/installer.sh

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,3 +46,4 @@
 - Switched to remote F-Droid badge and removed local image.
 - githelper newrepo now sets the initial branch to `main` and creates a private GitHub repository named after the directory.
 - Fixed githelper newrepo using '.' as the project name when run in the current directory.
+- Testing installer now clones the repo for bleeding edge installs.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ curl -L https://github.com/alexknuckles/termux-scripts/releases/latest/download/
 To install the testing version run:
 
 ```bash
-curl -L https://github.com/alexknuckles/termux-scripts/releases/download/testing/installer.sh | bash -s -- -r
+curl -L https://github.com/alexknuckles/termux-scripts/releases/download/testing/installer.sh | bash
 ```
 
 Use `-g` to clone the repository to `~/git/termux-scripts` first and install from that local copy, avoiding an additional download.

--- a/scripts/testing_installer.sh
+++ b/scripts/testing_installer.sh
@@ -1,0 +1,15 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# testing_installer.sh - always install the latest bleeding-edge scripts
+# Usage: testing_installer.sh [installer options]
+# Dependencies: git, curl, jq
+# TAG: installer
+
+REPO_URL="https://github.com/alexknuckles/termux-scripts"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Clone the repo and execute the included installer with passed arguments
+git clone "$REPO_URL" "$TMP_DIR"
+exec "$TMP_DIR/scripts/installer.sh" "$@"


### PR DESCRIPTION
## Summary
- implement `testing_installer.sh` that clones the repo and runs the bundled installer
- upload the bleeding edge installer on prerelease events
- document testing install command
- note bleeding edge installer in changelog

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c41745cf48327a135837430ef766d