### PR TITLE
Remove repo-clone flag from installer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 - gnext -r now removes the `testing` tag and creates a release tag.
 - Pre-releases now list commits since the previous tag when creating GitHub releases.
 - githelper-setnextall shortcut no longer forces the `testing` tag.
-- Installer with `-g` clones first and installs from the clone to avoid duplicate downloads.
+- Removed the `-g` option from the installer. Use the testing installer to clone and install from the latest commit.
 - Documented Termux, Termux Widget and Termux API requirements with F-Droid links.
 - Installer now ensures `~/bin/termux-scripts` is on the PATH and exports it for immediate use.
 - Installer now appends the path to `~/.bashrc`, sources it and loads the alias file immediately.
@@ -47,3 +47,5 @@
 - githelper newrepo now sets the initial branch to `main` and creates a private GitHub repository named after the directory.
 - Fixed githelper newrepo using '.' as the project name when run in the current directory.
 - Testing installer now clones the repo for bleeding edge installs.
+- Release installer no longer clones the repo and README clarifies the usage.
+- Removed cleanup of old git clone path from installer uninstall routine.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ A collection of small utilities for the Termux environment.
 ## Installation
 Run `./scripts/installer.sh` to install the scripts. They are copied to `~/bin/termux-scripts`, shortcuts under `~/.shortcuts/termux-scripts`, and an alias file in `~/.aliases.d/`. Missing packages will be offered for installation automatically. The installer also sets executable permissions so commands like `gpullall` and `gpull` work immediately. It appends `~/bin/termux-scripts` to your `~/.bashrc` and exports it so the utilities are available right away. The alias file is sourced as soon as it's installed. Pass `-u` to remove everything created by a previous run.
 
-To install the stable release without cloning the repository run:
+To install the stable release run:
 
 ```bash
-curl -L https://github.com/alexknuckles/termux-scripts/releases/latest/download/installer.sh | bash -s -- -r
+curl -L https://github.com/alexknuckles/termux-scripts/releases/latest/download/installer.sh | bash
 ```
+This installer only installs the release files; it does not clone the repository.
 
 To install the testing version run:
 
@@ -30,7 +31,7 @@ To install the testing version run:
 curl -L https://github.com/alexknuckles/termux-scripts/releases/download/testing/installer.sh | bash
 ```
 
-Use `-g` to clone the repository to `~/git/termux-scripts` first and install from that local copy, avoiding an additional download.
+The testing installer automatically clones this repository to a temporary directory and installs from the latest commit.
 The installer updates your shell configuration to source every `*.aliases` file in `~/.aliases.d/` on startup.
 Shortcut scripts are located in the `termux-scripts-shortcuts` directory.
 Run the installer with `-u` to remove the symlinks, shortcuts and alias file and clean up the shell configuration. A new shell starts afterward so any loaded aliases are cleared.


### PR DESCRIPTION
## Summary
- drop `-g` clone option from `installer.sh`
- update README install notes to clarify release installer just installs files
- document installer change in CHANGES
- stop removing old `git/termux-scripts` clone during uninstall

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685c43fe57248327a19fab8d4f3572c5