### PR TITLE
Fix duplicate release uploads

### DIFF
--- a/.github/workflows/upload-installer.yml
+++ b/.github/workflows/upload-installer.yml
@@ -2,7 +2,7 @@ name: Upload installer
 
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
 
 permissions:
   contents: write
@@ -17,7 +17,7 @@ jobs:
         if: github.event.release.prerelease == true
         uses: softprops/action-gh-release@v1
         with:
-          files: scripts/testing_installer.sh#installer.sh
+          files: scripts/testing_installer.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,3 +51,4 @@
 - Removed cleanup of old git clone path from installer uninstall routine.
 - Added repo logo to README.
 - Arranged Termux app requirements into three columns in the README.
+- Upload workflow now triggers once and attaches the correct installer.


### PR DESCRIPTION
## Summary
- fix upload-installer GitHub Action so it only runs once per release
- attach testing or stable installer based on release type
- note workflow improvement in the changelog

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c6e9232948327a28831385255c738