### PR TITLE
Fix testing installer uploads

### DIFF
--- a/.github/workflows/upload-installer.yml
+++ b/.github/workflows/upload-installer.yml
@@ -2,7 +2,7 @@ name: Upload installer
 
 on:
   release:
-    types: [published]
+    types: [published, prereleased]
 
 permissions:
   contents: write

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,3 +52,4 @@
 - Added repo logo to README.
 - Arranged Termux app requirements into three columns in the README.
 - Upload workflow now triggers once and attaches the correct installer.
+- Testing installer now attaches to testing releases.


### PR DESCRIPTION
## Summary
- trigger the workflow on `prereleased` events
- document the fix in CHANGES

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c70b8652c83278a26d696155fabfb