### PR TITLE
Fix untagged testing releases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,3 +53,4 @@
 - Arranged Termux app requirements into three columns in the README.
 - Upload workflow now triggers once and attaches the correct installer.
 - Testing installer now attaches to testing releases.
+- githelper set-next now creates annotated tags and aborts if the push fails to prevent untagged releases.

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -317,8 +317,11 @@ set_next_release() {
     tag="testing"
     prerelease="--prerelease"
   fi
-  git tag -f "$tag"
-  git push -f origin "$tag" || true
+  git tag -af "$tag" -m "$tag"
+  if ! git push -f origin "$tag"; then
+    echo "Failed to push tag $tag" >&2
+    return 1
+  fi
   if command -v gh >/dev/null 2>&1; then
     if [ "$release" -eq 1 ]; then
       last=$(git tag -l 'v*' | sort -V | tail -n 1)


### PR DESCRIPTION
## Summary
- ensure `githelper set-next` tags are annotated
- abort on push failure so releases aren't created without tags
- update changelog

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c73f8faf08327b47aac0d703fcec2