### PR TITLE
Fix gnext prerelease update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,3 +54,4 @@
 - Upload workflow now triggers once and attaches the correct installer.
 - Testing installer now attaches to testing releases.
 - githelper set-next now creates annotated tags and aborts if the push fails to prevent untagged releases.
+- gnext now deletes the old testing release so GitHub Actions publishes a fresh prerelease.

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -334,6 +334,12 @@ set_next_release() {
       desc=$(git log --pretty='format:- %s' | head -n 20)
     fi
     flag="$prerelease"
+    if [ "$release" -eq 0 ] && gh release view "$tag" >/dev/null 2>&1; then
+      gh release delete -y "$tag" >/dev/null 2>&1 || true
+      if git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+        git push -d origin "$tag" >/dev/null 2>&1 || true
+      fi
+    fi
     if gh release view "$tag" >/dev/null 2>&1; then
       gh release edit "$tag" -n "$desc" -t "${tag^} Release" $flag || true
     else


### PR DESCRIPTION
## Summary
- delete old `testing` release so GitHub Actions publishes prereleases
- document fix in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c764fe9d083279b5846037f361e5f