### PR TITLE
Add default .gitignore in githelper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,3 +55,4 @@
 - Testing installer now attaches to testing releases.
 - githelper set-next now creates annotated tags and aborts if the push fails to prevent untagged releases.
 - gnext now deletes the old testing release so GitHub Actions publishes a fresh prerelease.
+- githelper now creates a default .gitignore to skip __pycache__ and other common cruft.

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -24,6 +24,21 @@ set -euo pipefail
 
 GIT_ROOT="${GIT_ROOT:-$HOME/git}"
 
+create_gitignore() {
+  cat > .gitignore <<'EOF'
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Backup files
+*~
+
+# OS generated files
+.DS_Store
+Thumbs.db
+EOF
+}
+
 pull_all() {
   local repo
   for repo in "$GIT_ROOT"/*/.git; do
@@ -112,6 +127,7 @@ init_here() {
     return
   fi
   git init -b main
+  [ -f .gitignore ] || create_gitignore
   git add -A
   git commit -m "Initial commit"
 }
@@ -191,6 +207,7 @@ new_repo() {
   mkdir -p "$dir"
   cd "$dir"
   git init -b main
+  [ -f .gitignore ] || create_gitignore
   git add -A
   if git diff --cached --quiet 2>/dev/null; then
     git commit --allow-empty -m "Initial commit"


### PR DESCRIPTION
## Summary
- create `create_gitignore` helper for githelper
- ensure `init` and `newrepo` generate `.gitignore`
- log change in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c9e2cea3483279a734911b8a7f9b5