### PR TITLE
Enhance wallai.sh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,3 +57,6 @@
 - gnext now deletes the old testing release so GitHub Actions publishes a fresh prerelease.
 - githelper now creates a default .gitignore to skip __pycache__ and other common cruft.
 - wallai now supports a `-y` flag for picking a visual style. Styles are chosen at random if omitted, and the theme list has been expanded.
+- wallai gains theme and style weighting, negative prompt support with `-n`,
+  Pollinations parameters for logo removal and enhancement, slugified filenames
+  and seed logging for repeatable generations.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ due to low quality. The default model is `flux`.
 
 ### Usage
 ```bash
-wallai [-p "prompt text"] [-t theme] [-y style] [-m model] [-r] [-s]
+wallai [-p "prompt text"] [-t theme] [-y style] [-m model] [-r] [-s] [-n "text"]
 ```
 
 Environment variables:
@@ -87,15 +87,18 @@ Flags:
 - `-r` Pick a random model from the available list, excluding `gptimage` and `turbo`.
 - `-s` Save the latest generated wallpaper to `~/pictures/saved-generated-wallpapers/` with the prompt embedded using `exiftool`.
   When used without other options, `wallai -s` archives the most recent wallpaper without generating a new one.
+- `-n` Custom negative prompt. Defaults to `blurry, low quality, deformed, disfigured, out of frame, low contrast, bad anatomy`.
+
+The final prompt is built as `(theme:1.5) description (style:1.3) [negative prompt: ...]` so the generated image strongly reflects the chosen theme and style.
 
 After showing the chosen prompt, the script also prints which Pollinations model will
 be used for image generation.
 
 If no prompt is provided, the script retrieves a themed picture description from the Pollinations text
-API using a random genre such as fantasy or cyberpunk. A random visual style such as watercolor or
-pixel art is also selected unless you supply `-y style`. You can override the random theme with
-`-t theme`. The API is asked to respond in exactly 15 words. A random seed parameter ensures that
-repeated calls yield different descriptions even when the theme is the same.
+API using a random genre such as **dreamcore** or **cyberpunk metropolis**. A style such as
+**unreal engine** or **cinematic lighting** is also selected unless you supply `-y style`.
+You can override the random theme with `-t theme`. The API is asked to respond in exactly 15 words
+and the same seed is used for both text and image generation so results can be repeated.
 
 Dependencies: `curl`, `jq`, `termux-wallpaper`, optional `exiftool` for the `-s` option (also used by the `walsave` alias).
 Images are saved as PNG or JPEG depending on what the API returns.


### PR DESCRIPTION
## Summary
- add negative prompt support and extra parameters
- emphasize theme and style in the final prompt
- slugify theme and style in output filename
- document new flags and behavior

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685da486bb808327bed49a791b43bd70