### PR TITLE
Fix duplicate spinner message

### DIFF
--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -341,7 +341,6 @@ generate_pollinations() {
   fi
 }
 
-echo "🎨 Generating image..."
 ctype_file=$(mktemp)
 generate_pollinations "$tmp_output" "$ctype_file" &
 gen_pid=$!


### PR DESCRIPTION
## Summary
- remove redundant `echo` before the spinner in `wallai.sh`

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685db34c09b883279d22701636e78f8b