### PR TITLE
Add fallback prompts for wallai

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,3 +62,5 @@
   and seed logging for repeatable generations.
 - wallai adds a favorites system via `-f`, inspired mode with `-i`,
   weather-aware prompting with `-w` and an emoji spinner during image generation.
+- wallai now falls back to a local list of prompts if the API request fails.
+- wallai retries Pollinations API calls and prints the success message on a new line.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ API using a random genre such as **dreamcore** or **cyberpunk metropolis**. A st
 **unreal engine** or **cinematic lighting** is also selected unless you supply `-y style`.
 You can override the random theme with `-t theme`. The API is asked to respond in exactly 15 words
 and the same seed is used for both text and image generation so results can be repeated.
+If the request fails, wallai retries up to three times before choosing a prompt from a built-in
+fallback list so generation can continue offline. Image generation itself also retries if the
+initial request fails.
 
 Dependencies: `curl`, `jq`, `termux-wallpaper`, optional `exiftool` for the `-f` option (also used by the `walfave` alias).
 Images are saved as PNG or JPEG depending on what the API returns.


### PR DESCRIPTION
## Summary
- handle Pollinations text API failures by picking a prompt from a local list
- document the new behavior in README
- note the change in CHANGES

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685db4324b7c832780f14cf2a3be5b94