### PR TITLE
fix newline before success message

### DIFF
--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -367,6 +367,7 @@ while true; do
   status=$?
   kill "$spin_pid" 2>/dev/null || true
   wait "$spin_pid" 2>/dev/null || true
+  printf '\n'
   if [ "$status" -eq 0 ]; then
     break
   fi


### PR DESCRIPTION
## Summary
- fix newline output after spinner in `wallai.sh`

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685db7262ebc8327aa4ad3e472eab683