### PR TITLE
Fix wallai invalid image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,3 +64,4 @@
   weather-aware prompting with `-w` and an emoji spinner during image generation.
 - wallai now falls back to a local list of prompts if the API request fails.
 - wallai retries Pollinations API calls and prints the success message on a new line.
+- wallai validates downloaded files and retries if the file is not an image.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -370,6 +370,16 @@ while true; do
   wait "$spin_pid" 2>/dev/null || true
   printf '\n'
   if [ "$status" -eq 0 ]; then
+    generated_content_type=$(cat "$ctype_file" 2>/dev/null || true)
+    file_type=$(file -b --mime-type "$tmp_output" 2>/dev/null || true)
+    if printf '%s' "$generated_content_type" | grep -qi '^image/' && \
+       printf '%s' "$file_type" | grep -qi '^image/'; then
+      break
+    fi
+    echo "❌ Invalid image file!" >&2
+    status=1
+  fi
+  if [ "$status" -eq 0 ]; then
     break
   fi
   if [ "$attempt" -ge 3 ]; then


### PR DESCRIPTION
## Summary
- retry wallai when Pollinations returns a non-image
- document the fix in CHANGES

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685dba8aa48483278817e99e224e47ce