### PR TITLE
Include default themes and styles in wallai config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,3 +67,4 @@
 - wallai validates downloaded files and retries if the file is not an image.
 - wallai supports per-group configuration with auto-bootstrap, discovery mode via `-d`,
   group-based favorites with `-f [group]` and generation with `-g [group]`.
+- Config bootstrapping now includes the full list of default themes and styles.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,12 @@ Flags:
 Wallai keeps per-group settings in `~/.wallai/config.yml`. The file is created
 automatically with a `main` group on first run. Each group can specify a
 favorites path, whether NSFW prompts are allowed, the prompt model used for
-discovery and lists of themes and styles.
+discovery and lists of themes and styles. The default configuration also
+includes all built‑in themes
+(`dreamcore`, `mystical forest`, `cosmic horror`, `ethereal landscape`,
+`retrofuturism`, `alien architecture`, `cyberpunk metropolis`) and styles
+(`unreal engine`, `cinematic lighting`, `octane render`, `hyperrealism`,
+`volumetric lighting`, `high detail`, `4k concept art`).
 
 The final prompt is built as `(theme:1.5) description (style:1.3) [negative prompt: ...]` so the generated image strongly reflects the chosen theme and style.
 

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -112,11 +112,21 @@ groups:
     prompt_model: default
     allow_prompt_fetch: true
     themes:
+      - dreamcore
       - mystical forest
+      - cosmic horror
+      - ethereal landscape
       - retrofuturism
+      - alien architecture
+      - cyberpunk metropolis
     styles:
       - unreal engine
       - cinematic lighting
+      - octane render
+      - hyperrealism
+      - volumetric lighting
+      - high detail
+      - 4k concept art
 EOF
 fi
 


### PR DESCRIPTION
## Summary
- populate wallai bootstrap config with the entire list of default themes and styles
- document the full defaults in the README
- note the change in CHANGES

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685de83134708327b80f6c8466cff677