### PR TITLE
Fix -d optional arg in wallai

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,3 +69,4 @@
   group-based favorites with `-f [group]` and generation with `-g [group]`.
 - Config bootstrapping now includes the full list of default themes and styles.
 - wallai now supports a -v flag to print API URLs and responses.
+- Fixed `-d` erroneously consuming the next flag as its argument. Verbose mode now works with discovery.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -77,7 +77,12 @@ while getopts ":p:t:m:y:rn:f:g:d:iwv" opt; do
       gen_group="$OPTARG"
       ;;
     d)
-      discovery_mode="$OPTARG"
+      if [ -n "${OPTARG:-}" ] && [ "${OPTARG:0:1}" != "-" ]; then
+        discovery_mode="$OPTARG"
+      else
+        discovery_mode="both"
+        [ -n "${OPTARG:-}" ] && OPTIND=$((OPTIND - 1))
+      fi
       ;;
     i)
       inspired_mode=true


### PR DESCRIPTION
## Summary
- handle `-d` without args correctly in `wallai.sh`
- document fix in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`


------
https://chatgpt.com/codex/tasks/task_e_685df4b9c4808327ab332a5506966dc4