### PR TITLE
Add help flag to wallai

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,3 +72,4 @@
 - Fixed `-d` erroneously consuming the next flag as its argument. Verbose mode now works with discovery.
 - Added `-l` to wallai to reuse theme and style from the last image.
 - wallai now uses unique seeds for discovery and logs them for repeatability.
+- wallai now supports a `-h` flag to display usage information.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ due to low quality. The default model is `flux`.
 ### Usage
 ```bash
 wallai [-p "prompt text"] [-t theme] [-y style] [-m model] [-r] \
-       [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n "text"]
+       [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n "text"] [-h]
 ```
 
 Environment variables:
@@ -94,6 +94,7 @@ Flags:
 - `-l` Use the theme and style from the last generated image if either is omitted.
 - `-n` Custom negative prompt. Defaults to `blurry, low quality, deformed, disfigured, out of frame, low contrast, bad anatomy`.
 - `-v` Enable verbose output for API requests and responses.
+- `-h` Show help and exit.
 
 Wallai keeps per-group settings in `~/.wallai/config.yml`. The file is created
 automatically with a `main` group on first run. Each group can specify a

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Usage: wallai.sh [-p "prompt text"] [-t theme] [-y style] [-m model] [-r]
 #                  [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l]
-#                  [-n "text"] [-v]
+#                  [-n "text"] [-v] [-h]
 #   -p  custom prompt instead of random theme
 #   -t  choose a theme when fetching the random prompt
 #   -y  pick a visual style or use a random one
@@ -19,12 +19,35 @@ set -euo pipefail
 #   -l  use the theme/style from the last image if not provided
 #   -n  custom negative prompt
 #   -v  verbose output for troubleshooting
+#   -h  show this help message
 #
 # Dependencies: curl, jq, termux-wallpaper, optional exiftool for -f
 # Output: saves the generated image to ~/pictures/generated-wallpapers and sets
 #         the current wallpaper
 # TAG: wallpaper
 # TAG: ai
+
+show_help() {
+  cat <<'EOF'
+Usage: wallai.sh [-p "prompt text"] [-t theme] [-y style] [-m model] [-r]
+                 [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l]
+                 [-n "text"] [-v] [-h]
+  -p  custom prompt instead of random theme
+  -t  choose a theme when fetching the random prompt
+  -y  pick a visual style or use a random one
+  -m  Pollinations model (default "flux")
+  -r  select a random model from the available list
+  -f  mark the generated wallpaper as a favorite in the optional group
+  -g  generate using config from the specified group
+  -d  discover a new theme/style (mode: theme, style or both)
+  -i  pick theme and style inspired by past favorites
+  -w  add weather, time and holiday context to the prompt
+  -l  use the theme/style from the last image if not provided
+  -n  custom negative prompt
+  -v  verbose output for troubleshooting
+  -h  show this help message
+EOF
+}
 
 # Check dependencies early so the script fails with a clear message
 for cmd in curl jq termux-wallpaper; do
@@ -50,7 +73,7 @@ weather_flag=false
 use_last=false
 generation_opts=false
 verbose=false
-while getopts ":p:t:m:y:rn:f:g:d:iwvl" opt; do
+while getopts ":p:t:m:y:rn:f:g:d:iwvlh" opt; do
   case "$opt" in
     p)
       prompt="$OPTARG"
@@ -104,6 +127,10 @@ while getopts ":p:t:m:y:rn:f:g:d:iwvl" opt; do
     v)
       verbose=true
       ;;
+    h)
+      show_help
+      exit 0
+      ;;
     :)
       case "$OPTARG" in
         f)
@@ -117,13 +144,13 @@ while getopts ":p:t:m:y:rn:f:g:d:iwvl" opt; do
           discovery_mode="both"
           ;;
         *)
-          echo "Usage: wallai.sh [-p \"prompt text\"] [-t theme] [-y style] [-m model] [-r] [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n \"text\"] [-v]" >&2
+          echo "Usage: wallai.sh [-p \"prompt text\"] [-t theme] [-y style] [-m model] [-r] [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n \"text\"] [-v] [-h]" >&2
           exit 1
           ;;
       esac
       ;;
     *)
-      echo "Usage: wallai.sh [-p \"prompt text\"] [-t theme] [-y style] [-m model] [-r] [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n \"text\"] [-v]" >&2
+      echo "Usage: wallai.sh [-p \"prompt text\"] [-t theme] [-y style] [-m model] [-r] [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n \"text\"] [-v] [-h]" >&2
       exit 1
       ;;
   esac
@@ -391,7 +418,7 @@ fi
 # wallai.sh - generate a wallpaper using Pollinations
 #
 # Usage: wallai.sh [-p "prompt text"] [-t theme] [-y style] [-m model] [-r] [-f]
-#                  [-g group] [-d mode] [-i] [-w] [-l] [-n "text"] [-v]
+#                  [-g group] [-d mode] [-i] [-w] [-l] [-n "text"] [-v] [-h]
 # Environment variables:
 #   ALLOW_NSFW         Set to 'false' to disallow NSFW prompts (default 'true')
 # Flags:
@@ -409,6 +436,7 @@ fi
 #   -l              Use theme and/or style from the last image
 #   -n text         Override the default negative prompt
 #   -v              Enable verbose output
+#   -h              Show help and exit
 #
 # Dependencies: curl, jq, termux-wallpaper, optional exiftool for -f
 # Output: saves the generated image under ~/pictures/generated-wallpapers


### PR DESCRIPTION
## Summary
- add `-h` help flag for `wallai`
- document usage in README
- note the change in CHANGES

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e045cd8e48327955192a26b294dc0