### PR TITLE
Alphabetize wallai help flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,31 +70,31 @@ due to low quality. The default model is `flux`.
 
 ### Usage
 ```bash
-wallai [-p "prompt text"] [-t theme] [-y style] [-m model] [-r] \
-       [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n "text"] [-h]
+wallai [-d [mode]] [-f [group]] [-g [group]] [-h] [-i] [-l] [-m model] \
+       [-n "text"] [-p "prompt text"] [-r] [-t theme] [-v] [-w] [-y style]
 ```
 
 Environment variables:
 - `ALLOW_NSFW` set to `false` to disallow NSFW prompts (defaults to `true`).
 
 Flags:
-- `-p` Specify your own prompt instead of fetching a random one.
-- `-t` Choose a theme for the random prompt (ignored if `-p` is used).
-- `-y` Select a visual style. If omitted, one is picked at random.
+- `-d [mode]` Discover a new theme and/or style using Pollinations. Modes are `theme`, `style` or both if omitted.
+- `-f [group]` Save the wallpaper to a favorites group (defaults to `main`).
+- `-g [group]` Generate using themes and styles from a group.
+- `-h` Show help and exit.
+- `-i` Choose a theme and style inspired by previous favorites.
+- `-l` Use the theme and style from the last generated image if either is omitted.
 - `-m` Select Pollinations model. Available models come from the API and usually
   include `flux`, `turbo` and `gptimage`. `flux` is used if none is provided.
   The `gptimage` model requires a flower-tier Pollinations account; without
   access the API returns an error. The `turbo` model tends to produce lower quality images.
-- `-r` Pick a random model from the available list, excluding `gptimage` and `turbo`.
-- `-f [group]` Save the wallpaper to a favorites group (defaults to `main`).
-- `-g [group]` Generate using themes and styles from a group.
-- `-d [mode]` Discover a new theme and/or style using Pollinations. Modes are `theme`, `style` or both if omitted.
-- `-i` Choose a theme and style inspired by previous favorites.
-- `-w` Append current weather, time, season and holiday to the prompt.
-- `-l` Use the theme and style from the last generated image if either is omitted.
 - `-n` Custom negative prompt. Defaults to `blurry, low quality, deformed, disfigured, out of frame, low contrast, bad anatomy`.
+- `-p` Specify your own prompt instead of fetching a random one.
+- `-r` Pick a random model from the available list, excluding `gptimage` and `turbo`.
+- `-t` Choose a theme for the random prompt (ignored if `-p` is used).
 - `-v` Enable verbose output for API requests and responses.
-- `-h` Show help and exit.
+- `-w` Append current weather, time, season and holiday to the prompt.
+- `-y` Select a visual style. If omitted, one is picked at random.
 
 Wallai keeps per-group settings in `~/.wallai/config.yml`. The file is created
 automatically with a `main` group on first run. Each group can specify a

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -3,23 +3,23 @@ set -euo pipefail
 
 # wallai.sh - generate a wallpaper using Pollinations
 #
-# Usage: wallai.sh [-p "prompt text"] [-t theme] [-y style] [-m model] [-r]
-#                  [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l]
-#                  [-n "text"] [-v] [-h]
-#   -p  custom prompt instead of random theme
-#   -t  choose a theme when fetching the random prompt
-#   -y  pick a visual style or use a random one
-#   -m  Pollinations model (default "flux")
-#   -r  select a random model from the available list
+# Usage: wallai.sh [-d [mode]] [-f [group]] [-g [group]] [-h] [-i] [-l] \
+#                  [-m model] [-n "text"] [-p "prompt text"] [-r] [-t theme] \
+#                  [-v] [-w] [-y style]
+#   -d  discover a new theme/style (mode: theme, style or both)
 #   -f  mark the generated wallpaper as a favorite in the optional group
 #   -g  generate using config from the specified group
-#   -d  discover a new theme/style (mode: theme, style or both)
-#   -i  pick theme and style inspired by past favorites
-#   -w  add weather, time and holiday context to the prompt
-#   -l  use the theme/style from the last image if not provided
-#   -n  custom negative prompt
-#   -v  verbose output for troubleshooting
 #   -h  show this help message
+#   -i  pick theme and style inspired by past favorites
+#   -l  use the theme/style from the last image if not provided
+#   -m  Pollinations model (default "flux")
+#   -n  custom negative prompt
+#   -p  custom prompt instead of random theme
+#   -r  select a random model from the available list
+#   -t  choose a theme when fetching the random prompt
+#   -v  verbose output for troubleshooting
+#   -w  add weather, time and holiday context to the prompt
+#   -y  pick a visual style or use a random one
 #
 # Dependencies: curl, jq, termux-wallpaper, optional exiftool for -f
 # Output: saves the generated image to ~/pictures/generated-wallpapers and sets
@@ -29,23 +29,24 @@ set -euo pipefail
 
 show_help() {
   cat <<'EOF'
-Usage: wallai.sh [-p "prompt text"] [-t theme] [-y style] [-m model] [-r]
-                 [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l]
-                 [-n "text"] [-v] [-h]
-  -p  custom prompt instead of random theme
-  -t  choose a theme when fetching the random prompt
-  -y  pick a visual style or use a random one
-  -m  Pollinations model (default "flux")
-  -r  select a random model from the available list
-  -f  mark the generated wallpaper as a favorite in the optional group
-  -g  generate using config from the specified group
-  -d  discover a new theme/style (mode: theme, style or both)
-  -i  pick theme and style inspired by past favorites
-  -w  add weather, time and holiday context to the prompt
-  -l  use the theme/style from the last image if not provided
-  -n  custom negative prompt
-  -v  verbose output for troubleshooting
-  -h  show this help message
+Usage: wallai.sh [-d [mode]] [-f [group]] [-g [group]] [-h] [-i] [-l] \
+                 [-m model] [-n "text"] [-p "prompt text"] [-r] [-t theme] \
+                 [-v] [-w] [-y style]
+
+  -d [mode]   discover a new theme/style (mode: theme, style or both)
+  -f [group]  mark the generated wallpaper as a favorite in the optional group
+  -g [group]  generate using config from the specified group
+  -h          show this help message
+  -i          pick theme and style inspired by past favorites
+  -l          use the theme/style from the last image if not provided
+  -m model    Pollinations model (default "flux")
+  -n text     custom negative prompt
+  -p text     custom prompt instead of random theme
+  -r          select a random model from the available list
+  -t theme    choose a theme when fetching the random prompt
+  -v          verbose output for troubleshooting
+  -w          add weather, time and holiday context to the prompt
+  -y style    pick a visual style or use a random one
 EOF
 }
 
@@ -144,13 +145,13 @@ while getopts ":p:t:m:y:rn:f:g:d:iwvlh" opt; do
           discovery_mode="both"
           ;;
         *)
-          echo "Usage: wallai.sh [-p \"prompt text\"] [-t theme] [-y style] [-m model] [-r] [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n \"text\"] [-v] [-h]" >&2
+          echo "Usage: wallai.sh [-d [mode]] [-f [group]] [-g [group]] [-h] [-i] [-l] [-m model] [-n \"text\"] [-p \"prompt text\"] [-r] [-t theme] [-v] [-w] [-y style]" >&2
           exit 1
           ;;
       esac
       ;;
     *)
-      echo "Usage: wallai.sh [-p \"prompt text\"] [-t theme] [-y style] [-m model] [-r] [-f [group]] [-g [group]] [-d [mode]] [-i] [-w] [-l] [-n \"text\"] [-v] [-h]" >&2
+      echo "Usage: wallai.sh [-d [mode]] [-f [group]] [-g [group]] [-h] [-i] [-l] [-m model] [-n \"text\"] [-p \"prompt text\"] [-r] [-t theme] [-v] [-w] [-y style]" >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
## Summary
- sort wallai's usage flags alphabetically and align descriptions
- update README usage section with new flag order

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e064f9a54832780f37c4604f9d519