### PR TITLE
Fix docs for -i and -t flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Flags:
 - `-f [group]` Save the wallpaper to a favorites group (defaults to `main`).
 - `-g [group]` Generate using themes and styles from a group.
 - `-h` Show help and exit.
-- `-i [group]` Choose a theme and style inspired by favorites from the specified group.
+- `-i [group]` Choose a theme and style inspired by favorites from the specified group (defaults to `main`).
 - `-l` Use the theme and style from the last generated image if either is omitted.
 - `-m` Select Pollinations model. Available models come from the API and usually
   include `flux`, `turbo` and `gptimage`. `flux` is used if none is provided.
@@ -91,7 +91,7 @@ Flags:
 - `-n` Custom negative prompt. Defaults to `blurry, low quality, deformed, disfigured, out of frame, low contrast, bad anatomy`.
 - `-p` Specify your own prompt instead of fetching a random one.
 - `-r` Pick a random model from the available list, excluding `gptimage` and `turbo`.
-- `-t` Choose a theme for the random prompt (ignored if `-p` is used).
+- `-t` Choose a theme (ignored if `-p` is used).
 - `-v` Enable verbose output for API requests and responses.
 - `-w` Append current weather, time, season and holiday to the prompt.
 - `-y` Select a visual style. If omitted, one is picked at random.
@@ -114,7 +114,7 @@ be used for image generation.
 If no prompt is provided, the script retrieves a themed picture description from the Pollinations text
 API using a random genre such as **dreamcore** or **cyberpunk metropolis**. A style such as
 **unreal engine** or **cinematic lighting** is also selected unless you supply `-y style`.
-You can override the random theme with `-t theme`. The API is asked to respond in exactly 15 words
+You can set the theme with `-t theme`. The API is asked to respond in exactly 15 words
 and each API request uses a new seed. These seeds are stored so results can be repeated.
 If the request fails, wallai retries up to three times before choosing a prompt from a built-in
 fallback list so generation can continue offline. Image generation itself also retries if the

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -10,13 +10,13 @@ set -euo pipefail
 #   -f  mark the generated wallpaper as a favorite in the optional group
 #   -g  generate using config from the specified group
 #   -h  show this help message
-#   -i  pick theme and style inspired by past favorites from the optional group
+#   -i  pick theme and style inspired by past favorites from the optional group (defaults to "main")
 #   -l  use the theme/style from the last image if not provided
 #   -m  Pollinations model (default "flux")
 #   -n  custom negative prompt
 #   -p  custom prompt instead of random theme
 #   -r  select a random model from the available list
-#   -t  choose a theme when fetching the random prompt
+#   -t  choose a theme (ignored if -p is used)
 #   -v  verbose output for troubleshooting
 #   -w  add weather, time and holiday context to the prompt
 #   -y  pick a visual style or use a random one
@@ -37,13 +37,13 @@ Usage: wallai.sh [-d [mode]] [-f [group]] [-g [group]] [-h] [-i [group]] [-l] \
   -f [group]  mark the generated wallpaper as a favorite in the optional group
   -g [group]  generate using config from the specified group
   -h          show this help message
-  -i [group]  pick theme and style inspired by past favorites from the optional group
+  -i [group]  pick theme and style inspired by past favorites from the optional group (defaults to "main")
   -l          use the theme/style from the last image if not provided
   -m model    Pollinations model (default "flux")
   -n text     custom negative prompt
   -p text     custom prompt instead of random theme
   -r          select a random model from the available list
-  -t theme    choose a theme when fetching the random prompt
+  -t theme    choose a theme (ignored if -p is used)
   -v          verbose output for troubleshooting
   -w          add weather, time and holiday context to the prompt
   -y style    pick a visual style or use a random one
@@ -441,7 +441,7 @@ fi
 #   ALLOW_NSFW         Set to 'false' to disallow NSFW prompts (default 'true')
 # Flags:
 #   -p prompt text  Custom prompt instead of random theme
-#   -t theme        Specify theme when fetching random prompt
+#   -t theme        Specify theme (ignored if -p is used)
 #   -y style        Pick a visual style or use a random one
 #   -m model        Pollinations model (defaults to 'flux'). Supported models
 #                   are fetched from the API (fallback: flux turbo gptimage)
@@ -449,7 +449,7 @@ fi
 #   -f              Mark the latest generated wallpaper as a favorite
 #   -g group        Generate using config from the specified group
 #   -d mode         Discover a new theme/style (theme, style or both)
-#   -i group        Choose theme and style inspired by favorites from the specified group
+#   -i group        Choose theme and style inspired by favorites from the specified group (defaults to "main")
 #   -w              Add weather, time and seasonal context
 #   -l              Use theme and/or style from the last image
 #   -n text         Override the default negative prompt


### PR DESCRIPTION
## Summary
- clarify the `-i` default group in wallai documentation
- remove wording implying `-t` only affects random prompts

## Testing
- `bash ./scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e0bde3570832792e9fd23bfe1d22d