### PR TITLE
Add interactive group prompt for walfave shortcut

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,3 +74,4 @@
 - wallai now uses unique seeds for discovery and logs them for repeatability.
 - wallai now supports a `-h` flag to display usage information.
 - wallai -i now accepts an optional group argument.
+- Added walfave-group-shortcut for selecting the favorites group via buttons.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ the image.
 
 The installer creates a `walfave` alias and `walfave-shortcut.sh` so you
 can archive the currently set wallpaper with metadata via `wallai -f` without generating a new image.
+It also installs `walfave-group-shortcut.sh` which lets you pick the favorites group using on-screen buttons.
 
 ## githelper.sh
 

--- a/termux-scripts-shortcuts/walfave-group-shortcut.sh
+++ b/termux-scripts-shortcuts/walfave-group-shortcut.sh
@@ -1,0 +1,35 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# walfave-group-shortcut.sh - choose a favorites group and archive the current wallpaper
+# TAG: shortcut
+
+config_file="$HOME/.wallai/config.yml"
+
+# Default to main if config missing
+if [ -f "$config_file" ]; then
+  mapfile -t groups < <(CFG="$config_file" python3 - <<'PY'
+import os, yaml
+with open(os.environ['CFG']) as f:
+    data = yaml.safe_load(f) or {}
+print('\n'.join((data.get('groups') or {}).keys()))
+PY
+  )
+else
+  groups=(main)
+fi
+
+[ "${#groups[@]}" -gt 0 ] || groups=(main)
+list=$(IFS=','; printf '%s' "${groups[*]}")
+
+if ! command -v termux-dialog >/dev/null 2>&1; then
+  echo "termux-dialog is required" >&2
+  exit 1
+fi
+
+result=$(termux-dialog -l "$list" -t "Select favorites group" || true)
+selection=$(printf '%s' "$result" | jq -r '.text')
+
+[ -n "$selection" ] || exit 0
+
+exec "$HOME/bin/termux-scripts/wallai" -f "$selection" "$@"


### PR DESCRIPTION
## Summary
- create `walfave-group-shortcut.sh` for choosing favorite groups
- document it in README
- note new shortcut in CHANGES

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ebf42a82883279f8878efe9f1b36c