### PR TITLE
Fix browse_gallery call before definition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,3 +76,5 @@
 - wallai -i now accepts an optional group argument.
 - Added walfave-group-shortcut for selecting the favorites group via buttons.
 - Added `-b` option to wallai for browsing existing wallpapers and favoriting them.
+
+- Fixed browse_gallery command not found when using -b due to call before function definition.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -258,12 +258,6 @@ insp_path=$(cfg "$inspired_group" '.groups[$g].path // empty')
 [ -z "$insp_path" ] && insp_path="$HOME/pictures/favorites/$inspired_group"
 insp_path=$(eval printf '%s' "$insp_path")
 
-# Open gallery if requested
-if [ "$browse_gallery" = true ]; then
-  browse_gallery "$browse_group"
-  exit 0
-fi
-
 # Discover new theme or style via Pollinations
 discover_item() {
   local kind="$1" query result dseed
@@ -426,6 +420,12 @@ PY
     cp "$save_dir/$sel" "$dest_path/" && echo "⭐ Added to favorites: $dest_path/$sel"
   fi
 }
+
+# Open gallery if requested
+if [ "$browse_gallery" = true ]; then
+  browse_gallery "$browse_group"
+  exit 0
+fi
 
 # Spinner that cycles through emojis while a command runs
 spinner() {


### PR DESCRIPTION
## Summary
- call `browse_gallery` after defining the function to avoid `command not found`
- note fix in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f26ddda6c8327af4e02c51212345e