### PR TITLE
Handle invalid JSON in wallai

### DIFF
--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -371,7 +371,10 @@ browse_gallery() {
   [ "${#images[@]}" -gt 0 ] || { echo "❌ No images found" >&2; return 1; }
   list=$(IFS=','; printf '%s' "${images[*]}")
   result=$(termux-dialog -l "$list" -t "Select wallpaper" || true)
-  sel=$(printf '%s' "$result" | jq -r '.text')
+  if ! sel=$(printf '%s' "$result" | jq -e -r '.text' 2>/dev/null); then
+    echo "❌ Invalid JSON from termux-dialog" >&2
+    return 1
+  fi
   [ -n "$sel" ] || return 0
   termux-open "$save_dir/$sel"
   result=$(termux-dialog -l "yes,no" -t "Add to favorites?" || true)


### PR DESCRIPTION
## Summary
- ensure `wallai.sh` checks the JSON output from `termux-dialog` before passing it to jq

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f302ebd5c8327bbad197e4691d51c