### PR TITLE
Fix wal browse gallery error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,3 +78,5 @@
 - Added `-b` option to wallai for browsing existing wallpapers and favoriting them.
 
 - Fixed browse_gallery command not found when using -b due to call before function definition.
+- Browse mode now redirects termux-dialog errors to avoid invalid JSON messages.
+- Tester agent requires running new scripts or commands before opening pull requests.

--- a/agents.md
+++ b/agents.md
@@ -135,6 +135,7 @@ Add frontmatter or inline tags for script categorization:
 **Goal:**
 If any scripts have flags or interactive input, generate minimal test cases or test harnesses.
 Specifically ensure `githelper newrepo` succeeds when run in an empty directory and creates an initial commit.
+Run any newly added or modified scripts, functions or commands before opening a pull request to confirm they execute without immediate errors.
 
 ---
 

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -370,14 +370,14 @@ browse_gallery() {
   mapfile -t images < <(ls -t -- *.jpg *.png 2>/dev/null || true)
   [ "${#images[@]}" -gt 0 ] || { echo "❌ No images found" >&2; return 1; }
   list=$(IFS=','; printf '%s' "${images[*]}")
-  result=$(termux-dialog -l "$list" -t "Select wallpaper" || true)
+  result=$(termux-dialog -l "$list" -t "Select wallpaper" 2>/dev/null || true)
   if ! sel=$(printf '%s' "$result" | jq -e -r '.text' 2>/dev/null); then
     echo "❌ Invalid JSON from termux-dialog" >&2
     return 1
   fi
   [ -n "$sel" ] || return 0
   termux-open "$save_dir/$sel"
-  result=$(termux-dialog -l "yes,no" -t "Add to favorites?" || true)
+  result=$(termux-dialog -l "yes,no" -t "Add to favorites?" 2>/dev/null || true)
   decision=$(printf '%s' "$result" | jq -r '.text')
   [ "$decision" = "yes" ] || return 0
   if [ -f "$config_file" ]; then


### PR DESCRIPTION
## Summary
- fix invalid JSON from `termux-dialog` in wallai browse mode
- require running any new scripts before PR in Tester agent
- record changes

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f31f592908327a06478848d6953f6