### PR TITLE
Fix wallai token handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,3 +81,5 @@
 - Browse mode now redirects termux-dialog errors to avoid invalid JSON messages.
 - Tester agent requires running new scripts or commands before opening pull requests.
 - wallai config now includes `pollinations_token` and the `-k` flag to save it.
+- wallai now saves the token under the chosen group and loads group tokens before the global one.
+- Discovery prompts instruct Pollinations to respond with exactly two words to avoid verbose replies.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Flags:
 - `-g [group]` Generate using themes and styles from a group.
 - `-h` Show help and exit.
 - `-i [group]` Choose a theme and style inspired by favorites from the specified group (defaults to `main`).
-- `-k token` Save your Pollinations token to the config for authenticated requests.
+- `-k token` Save your Pollinations token to the group used with `-g` (defaults to `main`).
 - `-l` Use the theme and style from the last generated image if either is omitted.
 - `-m` Select Pollinations model. Available models come from the API and usually
   include `flux`, `turbo` and `gptimage`. `flux` is used if none is provided.
@@ -100,8 +100,10 @@ Flags:
 Wallai keeps per-group settings in `~/.wallai/config.yml`. The file is created
 automatically with a `main` group on first run. Each group can specify a
 favorites path, whether NSFW prompts are allowed, the prompt model used for
-discovery and lists of themes and styles. A top-level `pollinations_token`
-field stores your API token if needed. The default configuration also
+discovery and lists of themes and styles. A Pollinations token can be stored for
+each group using `-k` (saved under that group's entry, default `main`). A
+top-level `pollinations_token` is still supported for backward compatibility.
+The default configuration also
 includes all built‑in themes
 (`dreamcore`, `mystical forest`, `cosmic horror`, `ethereal landscape`,
 `retrofuturism`, `alien architecture`, `cyberpunk metropolis`) and styles


### PR DESCRIPTION
## Summary
- save Pollinations token under the active group and load it before global token
- tighten discovery prompts to produce exactly two words
- document group token behavior in README
- update changelog

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `bash scripts/lint.sh`
- `bash scripts/wallai.sh -h` *(fails: Required command 'termux-wallpaper' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fca7b598483278690c4e0e0771143