### PR TITLE
Remove POLLINATIONS_TOKEN fallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,3 +92,4 @@
 - Added `-tm` and `-sm` flags for theme and style discovery models.
 - `-t` can be combined with `-p` and docs clarify the relationship.
 - Style flag renamed from `-y` to `-s`.
+- Removed fallback to POLLINATIONS_TOKEN environment variable; token must come from config.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -289,7 +289,6 @@ PY
 
 # Pollinations token from config (group-specific overrides global)
 pollinations_token=$(printf '%s' "$config_json" | jq -r --arg g "$gen_group" '.groups[$g].pollinations_token // .pollinations_token // ""')
-[ -z "$pollinations_token" ] && pollinations_token="${POLLINATIONS_TOKEN:-}"
 
 # Update token in config if -k was provided
 if [ -n "$new_token" ]; then


### PR DESCRIPTION
## Summary
- rely on wallai config for Pollinations tokens
- note removal in changelog

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`
- `bash scripts/wallai.sh -h` *(fails: Required command 'termux-wallpaper' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fe2e3afdc8327a833db4ccdb078a9