### PR TITLE
Fix wallai config nesting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,3 +93,4 @@
 - `-t` can be combined with `-p` and docs clarify the relationship.
 - Style flag renamed from `-y` to `-s`.
 - Removed fallback to POLLINATIONS_TOKEN environment variable; token must come from config.
+- Configuration values no longer appear at the top level of `config.yml`; they are stored under each group.

--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ automatically with a `main` group on first run. Each group can specify a
 favorites path, whether NSFW prompts are allowed, the prompt model used for
 discovery, the image model used for generation and lists of themes and styles.
 You can store a Pollinations token for each group using `-k`, saved under that
-group's entry. Global `pollinations_token`, `prompt_model` and
-`image_model` values are also supported for fallback when a group omits them.
+group's entry along with `prompt_model` and `image_model` preferences.
 The default configuration also
 includes all built‑in themes
 (`dreamcore`, `mystical forest`, `cosmic horror`, `ethereal landscape`,

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -249,15 +249,13 @@ config_file="$HOME/.wallai/config.yml"
 if [ ! -f "$config_file" ]; then
   mkdir -p "$(dirname "$config_file")"
   cat >"$config_file" <<'EOF'
-pollinations_token: ""
-image_model: flux
-prompt_model: default
 groups:
   main:
+    pollinations_token: ""
+    image_model: flux
+    prompt_model: default
     path: ~/pictures/favorites/main
     nsfw: false
-    prompt_model: default
-    image_model: flux
     allow_prompt_fetch: true
     themes:
       - dreamcore
@@ -287,8 +285,8 @@ json.dump(data, sys.stdout)
 PY
 )
 
-# Pollinations token from config (group-specific overrides global)
-pollinations_token=$(printf '%s' "$config_json" | jq -r --arg g "$gen_group" '.groups[$g].pollinations_token // .pollinations_token // ""')
+# Pollinations token from config
+pollinations_token=$(printf '%s' "$config_json" | jq -r --arg g "$gen_group" '.groups[$g].pollinations_token // ""')
 
 # Update token in config if -k was provided
 if [ -n "$new_token" ]; then
@@ -328,13 +326,13 @@ gen_path=$(eval printf '%s' "$gen_path")
 # shellcheck disable=SC2016
 gen_nsfw=$(cfg "$gen_group" '.groups[$g].nsfw // false')
 # shellcheck disable=SC2016
-gen_prompt_model=$(cfg "$gen_group" '.groups[$g].prompt_model // .prompt_model // "default"')
+gen_prompt_model=$(cfg "$gen_group" '.groups[$g].prompt_model // "default"')
 # shellcheck disable=SC2016
-gen_theme_model=$(cfg "$gen_group" '.groups[$g].theme_model // .theme_model // empty')
+gen_theme_model=$(cfg "$gen_group" '.groups[$g].theme_model // empty')
 # shellcheck disable=SC2016
-gen_style_model=$(cfg "$gen_group" '.groups[$g].style_model // .style_model // empty')
+gen_style_model=$(cfg "$gen_group" '.groups[$g].style_model // empty')
 # shellcheck disable=SC2016
-gen_image_model=$(cfg "$gen_group" '.groups[$g].image_model // .image_model // "flux"')
+gen_image_model=$(cfg "$gen_group" '.groups[$g].image_model // "flux"')
 # shellcheck disable=SC2016
 gen_allow_prompt_fetch=$(cfg "$gen_group" '.groups[$g].allow_prompt_fetch // true')
 # shellcheck disable=SC2016


### PR DESCRIPTION
## Summary
- keep all wallai settings under each group in `config.yml`
- document per-group token, prompt model and image model
- update changelog

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685fe57daa0c8327ad5393333bc84945