### PR TITLE
Fix wallai defaults and output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -96,3 +96,4 @@
 - Configuration values no longer appear at the top level of `config.yml`; they are stored under each group.
 - Wallai config now separates `favorites_path` and `generations_path` per group and auto-creates groups used with `-g`.
 - Fixed append_config_item not defined error when adding theme or style
+- wallai updates: NSFW defaults to true, fetch message shows model, discovery output no longer duplicates selected lines, prompts clean "create a wallpaper" phrases, and -f defaults to the -g group


### PR DESCRIPTION
## Summary
- default NSFW to true in config
- show model when fetching prompt
- hide duplicate theme/style output in discovery mode
- clean pollination prompt phrasing
- default `-f` to generation group

## Testing
- `bash scripts/lint.sh`
- `bash scripts/wallai.sh -h` *(fails: termux-wallpaper not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ff9fd131883278a34e6760d4b2b96