### PR TITLE
Support custom defaults for new wallai groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,3 +98,4 @@
 - Fixed append_config_item not defined error when adding theme or style
 - wallai updates: NSFW defaults to true, fetch message shows model, discovery output no longer duplicates selected lines, prompts clean "create a wallpaper" phrases, and -f defaults to the -g group
 - wallai improves favorite handling: -f uses -g group, ignores flag arguments, and token message only shows when the token is used.
+- New groups inherit custom models, themes and styles when created via -g and the main group defaults to NSFW disabled.


### PR DESCRIPTION
## Summary
- default main group nsfw to false
- allow new groups created via `-g` to inherit custom models, themes and styles
- document change

## Testing
- `bash scripts/lint.sh` *(fails: shellcheck is required)*
- `bash scripts/wallai.sh -h` *(fails: termux-wallpaper not installed)*
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860032e62a08327a156c32ada5c3b05