### PR TITLE
Improve wallai retry transparency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,3 +108,4 @@
   to be added from any group.
 - `-pm` during group creation now sets the `prompt_model.base` value.
 - Styles and themes are only appended to a group's lists if they aren't already present.
+- Discovery now excludes existing themes/styles in the request and shows attempt progress during discovery and image retries.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -545,17 +545,26 @@ PY
 
 # Discover new theme or style via Pollinations
 discover_item() {
-  local kind="$1" query result dseed m url item attempt lower_item exists
+  local kind="$1" query result dseed m url item attempt lower_item exists list
   if [ "$gen_allow_prompt_fetch" != true ]; then
     return
   fi
   case "$kind" in
-    theme) query="Imagine a theme in two words. Respond with only two words." ;;
-    style) query="Imagine an art style in two words. Respond with only two words." ;;
-    *) return ;;
+    theme)
+      list=$(printf '%s, ' "${gen_themes[@]}" | sed 's/, $//')
+      query="Imagine a two-word theme not including any of: ${list}. Respond with exactly two words."
+      ;;
+    style)
+      list=$(printf '%s, ' "${gen_styles[@]}" | sed 's/, $//')
+      query="Imagine a two-word art style not including any of: ${list}. Respond with exactly two words."
+      ;;
+    *)
+      return
+      ;;
   esac
   encoded=$(printf '%s' "$query" | jq -sRr @uri)
   for attempt in 1 2 3 4 5; do
+    echo "🔄 Discovering $kind (attempt $attempt/5)..."
     dseed=$(random_seed)
     m="$gen_prompt_model"
     case "$kind" in
@@ -1067,6 +1076,7 @@ generate_pollinations() {
 ctype_file=$(mktemp)
 attempt=1
 while true; do
+  echo "🖼  Generating image (attempt $attempt/3)..."
   generate_pollinations "$tmp_output" "$ctype_file" &
   gen_pid=$!
   spinner "$gen_pid" &


### PR DESCRIPTION
## Summary
- make discovery requests exclude existing themes/styles and show progress per attempt
- show attempt number when generating images
- document the improved transparency in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`
- `bash scripts/wallai.sh -h`

------
https://chatgpt.com/codex/tasks/task_e_686029b4675883279a309ff29b846d7d