### PR TITLE
Redirect discovery progress to stderr

### DIFF
--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -564,7 +564,7 @@ discover_item() {
   esac
   encoded=$(printf '%s' "$query" | jq -sRr @uri)
   for attempt in 1 2 3 4 5; do
-    echo "🔄 Discovering $kind (attempt $attempt/5)..."
+    echo "🔄 Discovering $kind (attempt $attempt/5)..." >&2
     dseed=$(random_seed)
     m="$gen_prompt_model"
     case "$kind" in


### PR DESCRIPTION
## Summary
- fix progress output from `wallai` discovery mode so status lines don't affect variable assignments

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68602cb285508327b215adea2f7e17ea