### PR TITLE
Update wallai discovery output and generation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,3 +110,4 @@
 - `-pm` during group creation now sets the `prompt_model.base` value.
 - Styles and themes are only appended to a group's lists if they aren't already present.
 - Discovery now excludes existing themes/styles in the request and shows attempt progress during discovery and image retries.
+- Generation no longer retries on failures, discovery messages combine theme and style with a spinner.

--- a/README.md
+++ b/README.md
@@ -130,9 +130,8 @@ API using a random genre such as **dreamcore** or **cyberpunk metropolis**. A st
 **unreal engine** or **cinematic lighting** is also selected unless you supply `-y style`.
 You can set the theme with `-t theme`. The API is asked to respond in exactly 15 words
 and each API request uses a new seed. These seeds are stored so results can be repeated.
-If the request fails, wallai retries up to three times before choosing a prompt from a built-in
-fallback list so generation can continue offline. Image generation itself also retries if the
-initial request fails.
+If the request fails, wallai chooses a prompt from a built-in
+fallback list so generation can continue offline. Image generation exits on failure without retrying.
 
 Dependencies: `curl`, `jq`, `termux-wallpaper`, optional `exiftool` for the `-f` option (also used by the `walfave` alias).
 Images are saved as PNG or JPEG depending on what the API returns.


### PR DESCRIPTION
## Summary
- simplify prompt and image generation retries
- condense discovery messages and show spinner
- document no-retry behavior

## Testing
- `bash scripts/lint.sh` *(fails: shellcheck not installed)*
- `bash scripts/wallai.sh -h` *(fails: termux-wallpaper not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686048e6f8d08327b69b66afd7439eb5