### PR TITLE
Fix wallai favorite group handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,3 +111,5 @@
 - Styles and themes are only appended to a group's lists if they aren't already present.
 - Discovery now excludes existing themes/styles in the request and shows attempt progress during discovery and image retries.
 - Generation no longer retries on failures, discovery messages combine theme and style with a spinner.
+- `-g` with `-f` now favorites the generated image to the `-g` group and the
+  generating image message prints on a single line.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Environment variables:
 
 - Flags:
 - `-d [mode]` Discover a new theme and/or style using Pollinations. Modes are `theme`, `style` or both if omitted.
-- `-f [group]` Save the wallpaper to a favorites group (defaults to `main`).
+- `-f [group]` Save the wallpaper to a favorites group (defaults to `main`; when
+  combined with `-g`, it uses that group if no favorites group is given).
 - `-g [group]` Generate using themes and styles from a group.
 - `-h` Show help and exit.
 - `-i [group]` Choose a theme and style inspired by favorites from the specified group (defaults to `main`).

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -91,6 +91,7 @@ favorite_wall=false
 favorite_group="main"
 favorite_group_provided=false
 gen_group="main"
+gen_group_set=false
 discovery_mode=""
 inspired_mode=false
 inspired_group="main"
@@ -180,6 +181,7 @@ while getopts ":p:t:s:rn:f:g:d:i:k:wvlhb:" opt; do
       ;;
     g)
       gen_group="$OPTARG"
+      gen_group_set=true
       ;;
     k)
       new_token="$OPTARG"
@@ -255,15 +257,15 @@ shift $((OPTIND - 1))
 
 # Adjust groups for favorites
 if [ "$favorite_wall" = true ]; then
-  if [ "$generation_opts" = false ]; then
+  if [ "$generation_opts" = false ] && [ "$gen_group_set" = false ]; then
     if [ "$favorite_group_provided" = true ]; then
       gen_group="$favorite_group"
     else
       favorite_group="main"
       gen_group="main"
     fi
-  elif [ "$favorite_group_provided" = false ]; then
-    favorite_group="$gen_group"
+  else
+    [ "$favorite_group_provided" = false ] && favorite_group="$gen_group"
   fi
 fi
 
@@ -792,7 +794,7 @@ spinner_multi() {
 }
 
 # If called only with -f, favorite the last generated wallpaper and exit early
-if [ "$favorite_wall" = true ] && [ "$generation_opts" = false ]; then
+if [ "$favorite_wall" = true ] && [ "$generation_opts" = false ] && [ "$gen_group_set" = false ]; then
   last_entry=$(tail -n1 "$main_log" 2>/dev/null || true)
   if [ -z "$last_entry" ]; then
     echo "❌ No wallpaper has been generated yet" >&2
@@ -1115,7 +1117,6 @@ generate_pollinations() {
 }
 
 ctype_file=$(mktemp)
-echo "🖼  Generating image..."
 generate_pollinations "$tmp_output" "$ctype_file" &
 gen_pid=$!
 spinner "$gen_pid" "Generating image" &


### PR DESCRIPTION
## Summary
- ensure `wallai -g foo -f` favorites to `foo`
- print the "Generating image" line once
- document new `-g` & `-f` behavior in README
- note the change in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68604c597f1c8327bca01ee144131a85