### PR TITLE
Add weights and batch mode to wallai

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,3 +114,4 @@
 - `-g` with `-f` now favorites the generated image to the `-g` group and the
   generating image message prints on a single line.
 - wallai adds mood prompts (-m), improved inspiration modes with weighted pairs, and a -u flag to reuse wallpapers.
+- wallai now supports weighted tags/styles in config and batch generation with `-x [count]`.


### PR DESCRIPTION
## Summary
- support inline weights for tags and styles in config
- compute weighted prompts and clamp weights
- allow `-x [count]` to generate multiple images
- update docs and changelog

## Testing
- `bash scripts/lint.sh` *(fails: shellcheck is required)*

------
https://chatgpt.com/codex/tasks/task_e_6860a959552483278b40dd94959480a4