### PR TITLE
Fix wallai yaml syntax check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+- Fixed YAML validation check causing unexpected token error in wallai.sh.
 - Fixed missing set_config_value definition causing command not found in wallai.
 - Fixed API token updates in wallai when using -k to avoid jq errors with YAML.
 - `-k` now saves the Pollinations token only under the selected group instead of

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -410,7 +410,6 @@ try:
 except Exception:
     sys.exit(1)
 PY
-then
   echo "❌ Invalid config.yml format. Please check YAML syntax or run yamllint." >&2
   cleanup_and_exit 1
 fi


### PR DESCRIPTION
## Summary
- fix YAML validation logic in `wallai.sh`
- document the fix in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_686150b9cba483279aaed447b2665961