### PR TITLE
Fix unbound variable check in wallai

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,3 +119,5 @@
 - Unified cleanup with interrupt trap and grouped help output with examples.
 - wallai infers mood in inspired mode, validates YAML on load, retries empty prompts,
   and can caption shared images via `--describe-image` or a single image argument.
+
+- Fixed unbound variable check for discovered tag/style arrays in wallai.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -1342,7 +1342,7 @@ if [ -z "$prompt" ]; then
       tag=$(printf '%s\n' "${tags[@]}" | shuf -n1)
     fi
   fi
-  if [ -z "$discovered_tag" ]; then
+  if [ "${#discovered_tags[@]}" -eq 0 ]; then
     echo "🔖 Selected tag: $tag"
   fi
 
@@ -1374,7 +1374,7 @@ if [ -z "$style" ]; then
     style=$(printf '%s\n' "${styles[@]}" | shuf -n1)
   fi
 fi
-if [ -z "$discovered_style" ]; then
+if [ "${#discovered_styles[@]}" -eq 0 ]; then
   echo "🖌 Selected style: $style"
 fi
 


### PR DESCRIPTION
## Summary
- avoid undefined `discovered_tag`/`discovered_style` variables
- document fix in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`
- `bash scripts/wallai.sh -p "test" -t "test" -s "style" -n "none" -im flux -pm default` *(fails: termux-wallpaper not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686151c4ff8c832796afd039e45bf4ee