### PR TITLE
Fix favorites update for weighted configs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,3 +121,4 @@
   and can caption shared images via `--describe-image` or a single image argument.
 
 - Fixed unbound variable check for discovered tag/style arrays in wallai.
+- Fixed crash when adding favorites when the config contained weighted tags or styles.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -660,7 +660,15 @@ if os.path.exists(cfg):
 grp = data.setdefault('groups', {}).setdefault(group, {})
 lst = grp.setdefault(list_name, [])
 item_lower = item.lower()
-if item_lower not in [i.lower() for i in lst]:
+
+def norm(x):
+    if isinstance(x, str):
+        return x.lower()
+    if isinstance(x, dict) and x:
+        return next(iter(x)).lower()
+    return str(x).lower()
+
+if item_lower not in [norm(i) for i in lst]:
     lst.append(item)
     with open(cfg, 'w') as f:
         yaml.safe_dump(data, f, sort_keys=False)


### PR DESCRIPTION
## Summary
- avoid crash when config contains weighted tag/style entries
- note fix in CHANGES

## Testing
- `bash scripts/wallai.sh -h` *(fails: Required command 'termux-wallpaper' is not installed)*
- `bash scripts/lint.sh` *(fails: shellcheck is required)*

------
https://chatgpt.com/codex/tasks/task_e_6861d21eda4483279213f0a98e08f475