### PR TITLE
Restrict Pollinations image models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,3 +127,6 @@
 - Default provider switched to Pollinations with configurable models and a global `defaults` section.
 - Pollinations image generation now uses the `flux` model with its dedicated endpoint.
 - Updated default configuration format with per-model providers and endpoints.
+
+- Pollinations text models now include only the supported list: llamascout, mistral, openai, openai-fast, openai-large, phi, qwen-coder, elixposearch, midijourney, searchgpt and openai-reasoning.
+- Pollinations image models restricted to flux, kontext, turbo and gptimage with flux as the default.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -418,8 +418,8 @@ api_providers:
       image: "https://image.pollinations.ai"
     api_key: ""
     models:
-      text: []
-      image: ["flux", "flux-realism", "flux-anime", "flux-3d", "any-dark", "turbo"]
+      text: ["llamascout", "mistral", "openai", "openai-fast", "openai-large", "phi", "qwen-coder", "elixposearch", "midijourney", "searchgpt", "openai-reasoning"]
+      image: ["flux", "kontext", "turbo", "gptimage"]
   openai:
     base:
       text: "https://api.openai.com/v1"


### PR DESCRIPTION
## Summary
- limit Pollinations image models to flux, kontext, turbo and gptimage
- document the new model list in CHANGES

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68648c7a00388327a1fb15016c8427d5