### PR TITLE
Show group when generating wallpaper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -140,3 +140,5 @@
 - Fixed default config to avoid duplicate keys so group config loads correctly
 - Added tests/test_wallai.sh and requirement to run it before pull requests.
 - Expanded wallai tests to generate images for all commands.
+
+- wallai displays the selected group before generating images.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -1814,6 +1814,7 @@ generated_content_type=""
 
 echo "🎨 Final prompt: $prompt"
 echo "🛠 Using model: $model"
+echo "👥 Generation group: $gen_group"
 
 # ✨ Step 3: Generate image via $provider
 


### PR DESCRIPTION
## Summary
- show active group on the generation screen in `wallai.sh`
- document the new output in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`
- `bash tests/test_wallai.sh` *(fails: invalid image file)*

------
https://chatgpt.com/codex/tasks/task_e_6865ca2e90c08327aad156df1fabb12d