### PR TITLE
Fix style selection message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,3 +142,4 @@
 - Expanded wallai tests to generate images for all commands.
 
 - wallai displays the selected group before generating images.
+- Selected style message prints after style selection.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -1661,9 +1661,6 @@ if [ -z "$prompt" ]; then
   if [ "${#discovered_tags[@]}" -eq 0 ] || [ "$tag_provided" = true ]; then
     echo "🔖 Selected tag: $tag"
   fi
-  if [ "${#discovered_styles[@]}" -eq 0 ] || [ "$style_provided" = true ]; then
-    echo "🖌 Selected style: $style"
-  fi
   if ! fetch_prompt; then
     echo "❌ Failed to fetch prompt. Using fallback."
     # Create tag-specific fallback prompts
@@ -1719,6 +1716,11 @@ if [ -z "$style" ]; then
     )
     style=$(printf '%s\n' "${styles[@]}" | shuf -n1)
   fi
+fi
+
+# Show the selected style once it has been determined
+if [ "${#discovered_styles[@]}" -eq 0 ] || [ "$style_provided" = true ]; then
+  echo "🖌 Selected style: $style"
 fi
 
 # Determine weights from config if not set by inspiration


### PR DESCRIPTION
## Summary
- print selected style after style is chosen so message isn't blank
- document style message change

## Testing
- `bash scripts/lint.sh` *(fails: shellcheck is required)*
- `bash tests/test_wallai.sh` *(failed to complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6865d66a1b088327a11436cd41834f94