### PR TITLE
Add web-based config editor for wallai

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,3 +144,4 @@
 - wallai displays the selected group before generating images.
 - Selected style message prints after style selection.
 - wallai tests now verify multiple flags can be used together.
+- Added web UI for editing the new SQLite config and a wallai-webui shortcut.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Run the installer with `-u` to remove the symlinks, shortcuts and alias file and
 
 Generates an AI-based wallpaper using OpenAI-compatible APIs. The script requests a 15-word
 description for a random theme using a random seed so prompts vary even for the same theme.
-Providers are configured in `~/.wallai/config.yml` with a global `defaults`
+Providers are configured in `~/.wallai/config.db` with a global `defaults`
 section choosing which provider and models to use. Pollinations is the default
 and works without an API key. It uses the `flux` model for image generation,
 but you can add OpenAI or OpenRouter keys and switch providers as needed.
@@ -118,8 +118,9 @@ Examples:
 Environment variables:
 - `ALLOW_NSFW` set to `false` to disallow NSFW prompts (defaults to `true`).
 
-Wallai keeps per-group settings in `~/.wallai/config.yml`. The file is created
+Wallai keeps per-group settings in `~/.wallai/config.db`. The file is created
 automatically with a `main` group on first run. Each group can specify
+Open `~/.wallai/ui/index.html` or run the `wallai-webui` shortcut to edit the database.
 paths for generated images and favorites, whether NSFW prompts are allowed,
 the prompt model used for discovery, the image model used for generation and
 lists of themes and styles.

--- a/termux-scripts-shortcuts/wallai-webui.sh
+++ b/termux-scripts-shortcuts/wallai-webui.sh
@@ -1,0 +1,7 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# wallai-webui.sh - open the WallAI web UI
+# TAG: shortcut
+
+termux-open "$HOME/.wallai/ui/index.html"

--- a/wallai-ui/index.html
+++ b/wallai-ui/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WallAI Config</title>
+  <script src="https://cdn.jsdelivr.net/npm/sql.js@1.6.2/dist/sql-wasm.js"></script>
+</head>
+<body>
+  <h1>WallAI Config Editor</h1>
+  <input type="file" id="import" accept=".db,.sqlite">
+  <button id="export">Export DB</button>
+
+  <h2>Tags</h2>
+  <input type="text" id="tag-input" placeholder="New tag">
+  <button id="add-tag">Add Tag</button>
+  <ul id="tags"></ul>
+
+<script>
+let SQL, db;
+
+function createTables() {
+  db.run(`CREATE TABLE IF NOT EXISTS providers(
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT CHECK(type IN ('text','image')) NOT NULL,
+    base_url TEXT NOT NULL,
+    api_key TEXT,
+    UNIQUE(name, type)
+  );`);
+  db.run(`CREATE TABLE IF NOT EXISTS models(
+    id INTEGER PRIMARY KEY,
+    provider_id INTEGER NOT NULL REFERENCES providers(id),
+    name TEXT NOT NULL,
+    alias TEXT
+  );`);
+  db.run(`CREATE TABLE IF NOT EXISTS groups(
+    id INTEGER PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    prompt_model TEXT,
+    image_model TEXT,
+    tag_model TEXT,
+    style_model TEXT,
+    allow_nsfw BOOLEAN DEFAULT 1
+  );`);
+  db.run(`CREATE TABLE IF NOT EXISTS tags(
+    id INTEGER PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+  );`);
+  db.run(`CREATE TABLE IF NOT EXISTS styles(
+    id INTEGER PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+  );`);
+  db.run(`CREATE TABLE IF NOT EXISTS moods(
+    id INTEGER PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+  );`);
+  db.run(`CREATE TABLE IF NOT EXISTS favorites(
+    id INTEGER PRIMARY KEY,
+    group_id INTEGER REFERENCES groups(id),
+    filename TEXT NOT NULL,
+    theme TEXT,
+    style TEXT,
+    mood TEXT,
+    prompt TEXT,
+    model TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );`);
+  db.run(`CREATE TABLE IF NOT EXISTS defaults(
+    key TEXT PRIMARY KEY,
+    value TEXT
+  );`);
+}
+
+function refreshTags() {
+  const list = document.getElementById('tags');
+  list.innerHTML = '';
+  const res = db.exec('SELECT id, name FROM tags ORDER BY name');
+  if (res[0]) {
+    res[0].values.forEach(row => {
+      const li = document.createElement('li');
+      li.textContent = row[1];
+      const del = document.createElement('button');
+      del.textContent = 'Delete';
+      del.onclick = () => {
+        db.run('DELETE FROM tags WHERE id=?', [row[0]]);
+        refreshTags();
+      };
+      li.appendChild(document.createTextNode(' '));
+      li.appendChild(del);
+      list.appendChild(li);
+    });
+  }
+}
+
+async function init() {
+  SQL = await initSqlJs({
+    locateFile: f => `https://cdn.jsdelivr.net/npm/sql.js@1.6.2/dist/${f}`
+  });
+  db = new SQL.Database();
+  createTables();
+  refreshTags();
+}
+
+document.getElementById('add-tag').onclick = () => {
+  const tag = document.getElementById('tag-input').value.trim();
+  if (!tag) return;
+  db.run('INSERT OR IGNORE INTO tags(name) VALUES(?)', [tag]);
+  document.getElementById('tag-input').value = '';
+  refreshTags();
+};
+
+document.getElementById('export').onclick = () => {
+  const data = db.export();
+  const blob = new Blob([data], {type: 'application/octet-stream'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'config.db';
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+document.getElementById('import').onchange = evt => {
+  const file = evt.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = e => {
+    const u8 = new Uint8Array(e.target.result);
+    db = new SQL.Database(u8);
+    createTables();
+    refreshTags();
+  };
+  reader.readAsArrayBuffer(file);
+};
+
+init();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `wallai-webui.sh` shortcut to open a browser
- ship a static HTML UI using sql.js for managing the SQLite config
- mention new SQLite database and web UI in README
- note the new feature in CHANGES

## Testing
- `bash scripts/lint.sh`
- `bash tests/test_wallai.sh`


------
https://chatgpt.com/codex/tasks/task_e_6865ec947a488327b1e27e986d594918