### PR TITLE
Add setup refresh script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -146,3 +146,5 @@
 - wallai tests now verify multiple flags can be used together.
 - Removed the web UI and wallai-webui shortcut.
 - `--describe-image` flag shortened to `-di`.
+
+- Added setup_refresh.sh and setup-resources.txt to prefetch APIs during setup.

--- a/scripts/setup_refresh.sh
+++ b/scripts/setup_refresh.sh
@@ -1,0 +1,42 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# setup_refresh.sh - download resources needed for offline use
+#
+# Usage: setup_refresh.sh
+# Dependencies: curl
+# Output: saves files under static/cache for later use
+# TAG: setup
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOURCE_LIST="$ROOT_DIR/static/setup-resources.txt"
+CACHE_DIR="$ROOT_DIR/static/cache"
+
+mkdir -p "$CACHE_DIR"
+
+if [ ! -f "$RESOURCE_LIST" ]; then
+  echo "Resource list not found: $RESOURCE_LIST" >&2
+  exit 1
+fi
+
+while IFS= read -r line || [ -n "$line" ]; do
+  # skip blank lines and comments
+  [ -z "$line" ] && continue
+  case "$line" in
+    \#*) continue ;;
+  esac
+  url="$(printf '%s' "$line" | awk '{print $1}')"
+  dest="$(printf '%s' "$line" | awk '{print $2}')"
+  if [ -z "$url" ] || [ -z "$dest" ]; then
+    echo "Invalid entry in $RESOURCE_LIST: $line" >&2
+    continue
+  fi
+  echo "Fetching $url -> $CACHE_DIR/$dest"
+  if ! curl -fsSL "$url" -o "$CACHE_DIR/$dest"; then
+    echo "Failed to download $url" >&2
+  fi
+
+done < "$RESOURCE_LIST"
+
+printf '\nSaved resources to %s\n' "$CACHE_DIR"

--- a/static/setup-resources.txt
+++ b/static/setup-resources.txt
@@ -1,0 +1,3 @@
+# URL destination-file
+https://api.github.com static-api.json
+https://raw.githubusercontent.com/alexknuckles/termux-scripts/main/README.md latest-readme.md


### PR DESCRIPTION
## Summary
- download external resources while network is available
- list URLs in `static/setup-resources.txt`
- document the new setup step in `CHANGES.md`

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`
- `bash scripts/setup_refresh.sh`

------
https://chatgpt.com/codex/tasks/task_e_68668f2ba1d0832792612b71e2676a9e