### PR TITLE
Improve walfave exit and add discovery shortcut

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -149,3 +149,5 @@
 
 - Added setup_refresh.sh and setup-resources.txt to prefetch APIs during setup.
 - Wallai tests now log failures under /tmp/wallai-tests and keep running so setup continues.
+- walfave alias now ignores failures so shortcuts exit cleanly.
+- Added waldis-shortcut for discovery-based generation.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ the image.
 The installer creates a `walfave` alias and `walfave-shortcut.sh` so you
 can archive the currently set wallpaper with metadata via `wallai -f` without generating a new image.
 It also installs `walfave-group-shortcut.sh` which lets you pick the favorites group using on-screen buttons.
+The `waldis` alias and `waldis-shortcut.sh` invoke `wallai -d` for discovery-based generation.
 
 ## githelper.sh
 

--- a/aliases/termux-scripts.aliases
+++ b/aliases/termux-scripts.aliases
@@ -1,6 +1,7 @@
 # Short aliases for Termux scripts
 alias wal='wallai'
-alias walfave='wallai -f'
+alias walfave='wallai -f || true'
+alias waldis='wallai -d'
 alias walgal='wallai -b'
 alias gpullall='githelper pull-all'
 alias gpull='githelper pull'

--- a/termux-scripts-shortcuts/waldis-shortcut.sh
+++ b/termux-scripts-shortcuts/waldis-shortcut.sh
@@ -1,0 +1,7 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# waldis-shortcut.sh - generate a wallpaper using discovery mode
+# TAG: shortcut
+
+exec "$HOME/bin/termux-scripts/wallai" -d "$@"

--- a/termux-scripts-shortcuts/walfave-shortcut.sh
+++ b/termux-scripts-shortcuts/walfave-shortcut.sh
@@ -4,4 +4,5 @@ set -euo pipefail
 # walfave-shortcut.sh - archive the latest generated wallpaper
 # TAG: shortcut
 
-exec "$HOME/bin/termux-scripts/wallai" -f "$@"
+"$HOME/bin/termux-scripts/wallai" -f "$@" || true
+exit 0


### PR DESCRIPTION
## Summary
- ensure the `walfave` alias ignores errors
- make `walfave-shortcut.sh` always return 0
- add `waldis-shortcut.sh` for discovery generation
- document shortcuts and alias in README
- note changes in CHANGES

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`
- `bash tests/test_wallai.sh`

------
https://chatgpt.com/codex/tasks/task_e_6866b16fbb108327822394aa83d6114d