### PR TITLE
Fix waldis alias to generate wallpaper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -151,3 +151,4 @@
 - Wallai tests now log failures under /tmp/wallai-tests and keep running so setup continues.
 - walfave alias now ignores failures so shortcuts exit cleanly.
 - Added waldis-shortcut for discovery-based generation.
+- waldis now calls `wallai -d -x` so discovery automatically generates a wallpaper.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ the image.
 The installer creates a `walfave` alias and `walfave-shortcut.sh` so you
 can archive the currently set wallpaper with metadata via `wallai -f` without generating a new image.
 It also installs `walfave-group-shortcut.sh` which lets you pick the favorites group using on-screen buttons.
-The `waldis` alias and `waldis-shortcut.sh` invoke `wallai -d` for discovery-based generation.
+The `waldis` alias and `waldis-shortcut.sh` invoke `wallai -d -x` so an image is generated after discovery.
 
 ## githelper.sh
 

--- a/aliases/termux-scripts.aliases
+++ b/aliases/termux-scripts.aliases
@@ -1,7 +1,7 @@
 # Short aliases for Termux scripts
 alias wal='wallai'
 alias walfave='wallai -f || true'
-alias waldis='wallai -d'
+alias waldis='wallai -d -x'
 alias walgal='wallai -b'
 alias gpullall='githelper pull-all'
 alias gpull='githelper pull'

--- a/termux-scripts-shortcuts/waldis-shortcut.sh
+++ b/termux-scripts-shortcuts/waldis-shortcut.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # waldis-shortcut.sh - generate a wallpaper using discovery mode
 # TAG: shortcut
 
-exec "$HOME/bin/termux-scripts/wallai" -d "$@"
+exec "$HOME/bin/termux-scripts/wallai" -d -x "$@"


### PR DESCRIPTION
## Summary
- invoke `wallai -d -x` from the `waldis` alias and shortcut so discovery actually generates an image
- update README and changelog

## Testing
- `bash scripts/lint.sh`
- `bash scripts/security_check.sh`
- `bash tests/test_wallai.sh` *(fails: generation tests couldn't run)*

------
https://chatgpt.com/codex/tasks/task_e_6866b62d9ebc83278d85e1094c21eda1