### PR TITLE
Fix wallai discovery application

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+- Fixed discovery tags and styles not applied when using -d -x.
 - wallai parallelizes `-x N` batches with a spinner and sets the wallpaper from the last image.
 - New groups now inherit unset settings from the main profile.
 - Fixed YAML validation check causing unexpected token error in wallai.sh.

--- a/scripts/wallai.sh
+++ b/scripts/wallai.sh
@@ -1530,12 +1530,13 @@ if [ "$group_created" = "1" ]; then
   fi
 fi
 if [ -n "$discovery_mode" ] && [ "$force_generate" = true ]; then
-  if [ -z "$tag" ] && [ "${#discovered_tags[@]}" -gt 0 ]; then
+  if [ "${#discovered_tags[@]}" -gt 0 ]; then
     tag=$(printf '%s\n' "${discovered_tags[@]}" | shuf -n1)
   fi
-  if [ -z "$style" ] && [ "${#discovered_styles[@]}" -gt 0 ]; then
+  if [ "${#discovered_styles[@]}" -gt 0 ]; then
     style=$(printf '%s\n' "${discovered_styles[@]}" | shuf -n1)
   fi
+  [ "$verbose" = true ] && echo "🎯 Using discovered tag/style: $tag / $style"
   if [ -z "$tag" ] && [ "${#gen_tags[@]}" -gt 0 ]; then
     tag=$(printf '%s\n' "${gen_tags[@]}" | shuf -n1)
   fi


### PR DESCRIPTION
## Summary
- apply discovery tag/style even when variables already set
- log chosen tag/style in verbose mode
- document the fix

## Testing
- `bash scripts/lint.sh`
- `bash tests/test_wallai.sh` *(fails: No image generated)*

------
https://chatgpt.com/codex/tasks/task_e_6866c1e497508327af97652bcf7b7015