### PR TITLE
Add wallai-go implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,3 +155,4 @@
 - Added waldis-shortcut for discovery-based generation.
 - waldis now calls `wallai -d -x` so discovery automatically generates a wallpaper.
 - wallai -d -x now shows the discovered tag and style without requiring -v.
+- Added wallai-go Go version for generating wallpapers.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ can archive the currently set wallpaper with metadata via `wallai -f` without ge
 It also installs `walfave-group-shortcut.sh` which lets you pick the favorites group using on-screen buttons.
 The `waldis` alias and `waldis-shortcut.sh` invoke `wallai -d -x` so an image is generated after discovery.
 
+## wallai-go
+
+A simplified Go version of wallai that fetches a wallpaper from the Pollinations API.
+
+### Usage
+```bash
+wallai-go -p "prompt" [-im model] [-x n] [-o dir] [-w=false]
+```
+
+Dependencies: `termux-wallpaper` (optional)
+
 ## githelper.sh
 
 <p align="center" style="margin-bottom:0;">

--- a/aliases/termux-scripts.aliases
+++ b/aliases/termux-scripts.aliases
@@ -1,5 +1,6 @@
 # Short aliases for Termux scripts
 alias wal='wallai'
+alias walgo='wallai-go'
 alias walfave='wallai -f || true'
 alias waldis='wallai -d -x'
 alias walgal='wallai -b'

--- a/cmd/wallai-go/main.go
+++ b/cmd/wallai-go/main.go
@@ -1,0 +1,82 @@
+// wallai-go - generate wallpapers via Pollinations API
+//
+// Usage: wallai-go -p "prompt" [-im model] [-x n] [-o dir] [-w]
+// Dependencies: termux-wallpaper (optional)
+// Output: saves images to the specified directory and sets the wallpaper
+// TAG: wallpaper
+// TAG: go
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func main() {
+	prompt := flag.String("p", "", "Prompt text")
+	model := flag.String("im", "flux", "Image model")
+	count := flag.Int("x", 1, "Number of images")
+	outDir := flag.String("o", filepath.Join(os.Getenv("HOME"), "pictures", "generated-wallpapers"), "Output directory")
+	setWall := flag.Bool("w", true, "Set wallpaper using termux-wallpaper")
+	flag.Parse()
+
+	if strings.TrimSpace(*prompt) == "" {
+		fmt.Fprintln(os.Stderr, "prompt required (-p)")
+		os.Exit(1)
+	}
+	if *count < 1 {
+		fmt.Fprintln(os.Stderr, "count must be > 0")
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(*outDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create output dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < *count; i++ {
+		enc := url.PathEscape(*prompt)
+		apiURL := fmt.Sprintf("https://image.pollinations.ai/prompt/%s?nologo=true&model=%s", enc, url.QueryEscape(*model))
+		resp, err := http.Get(apiURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to fetch image: %v\n", err)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			fmt.Fprintf(os.Stderr, "bad response: %s\n", resp.Status)
+			resp.Body.Close()
+			continue
+		}
+		ext := ".jpg"
+		if ct := resp.Header.Get("Content-Type"); strings.Contains(ct, "png") {
+			ext = ".png"
+		}
+		fname := fmt.Sprintf("wallai-%d-%d%s", time.Now().Unix(), i+1, ext)
+		fpath := filepath.Join(*outDir, fname)
+		f, err := os.Create(fpath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create file: %v\n", err)
+			resp.Body.Close()
+			continue
+		}
+		if _, err := io.Copy(f, resp.Body); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to save image: %v\n", err)
+		}
+		f.Close()
+		resp.Body.Close()
+		fmt.Println("saved", fpath)
+		if *setWall {
+			if _, err := exec.LookPath("termux-wallpaper"); err == nil {
+				_ = exec.Command("termux-wallpaper", "-f", fpath).Run()
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module termux-scripts
+
+go 1.21
+

--- a/termux-scripts-shortcuts/wallai-go-shortcut.sh
+++ b/termux-scripts-shortcuts/wallai-go-shortcut.sh
@@ -1,0 +1,7 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# wallai-go-shortcut.sh - launch the Go version of wallai
+# TAG: shortcut
+
+exec "$HOME/bin/termux-scripts/wallai-go" "$@"


### PR DESCRIPTION
## Summary
- implement a minimal Go rewrite of `wallai`
- add alias `walgo` and matching shortcut
- document the new utility in the README
- add a module file
- note change in CHANGES

## Testing
- `bash scripts/lint.sh`
- `bash tests/test_wallai.sh`


------
https://chatgpt.com/codex/tasks/task_e_68699fa0e47c8327a8be4fd003df9f7f